### PR TITLE
Add reflection service for nightly improvement notes

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -22,11 +22,11 @@ from services.generator import Generator
 from services.selector import Selector
 from services.analytics import AnalyticsService
 from services.kpi import KPIService
-from services.feedback import FeedbackService
 from services.planner import PlannerService
 from services.persona_store import PersonaStore
 from services.self_model import SelfModelService
 from services.optimizer import Optimizer
+from services.reflection import ReflectionService
 from services.logging_utils import get_logger
 
 logger = get_logger(__name__)
@@ -44,7 +44,7 @@ generator = Generator(persona_store, llm_adapter)
 selector = Selector(persona_store)
 analytics_service = AnalyticsService()
 kpi_service = KPIService()
-feedback_service = FeedbackService()
+reflection_service = ReflectionService()
 planner_service = PlannerService()
 self_model_service = SelfModelService(persona_store)
 optimizer = Optimizer()
@@ -374,10 +374,10 @@ async def nightly_reflection_job():
     """Perform nightly reflection and generate improvement note"""
     try:
         with get_db_session() as session:
-            improvement_note = feedback_service.generate_daily_improvement_note(session)
+            improvement_note = reflection_service.generate_reflection(session)
             await _log_action("nightly_reflection", {"note": improvement_note})
             logger.info(f"Nightly reflection completed: {improvement_note}")
-            
+
     except Exception as e:
         logger.error(f"Nightly reflection job failed: {e}")
 

--- a/services/reflection.py
+++ b/services/reflection.py
@@ -1,0 +1,43 @@
+"""Reflection service for generating improvement notes based on recent actions and metrics"""
+
+from sqlalchemy.orm import Session
+
+from services.memory import MemoryService
+from services.analytics import AnalyticsService
+from services.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class ReflectionService:
+    """Generates structured reflections from recent activity"""
+
+    def __init__(self) -> None:
+        self.memory = MemoryService()
+        self.analytics = AnalyticsService()
+
+    def generate_reflection(self, session: Session) -> str:
+        """Analyze recent actions and outcomes, recording a lesson learned."""
+        try:
+            recent_actions = self.memory.get_episodic_memory(session, hours=24)
+            fame_stats = self.analytics.calculate_fame_score(session, days=1)
+
+            if not recent_actions:
+                note = "No recent activity to reflect on. Increase engagement and output."
+            else:
+                engagement = fame_stats.get("engagement_proxy", 0.0)
+                follower_delta = fame_stats.get("follower_delta", 0.0)
+                note = (
+                    f"Reviewed {len(recent_actions)} actions. "
+                    f"Engagement {engagement:.1f}, follower change {follower_delta:.1f}."
+                )
+                if engagement < 10:
+                    note += " Consider posting more compelling content."
+                if follower_delta < 0:
+                    note += " Address follower decline."
+
+            self.memory.add_improvement_note(session, note)
+            return note
+        except Exception as exc:
+            logger.error(f"Reflection generation failed: {exc}")
+            return "Reflection failed. Review logs for details."

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from services.reflection import ReflectionService
+
+class TestReflectionService:
+    def test_generate_reflection_with_activity(self):
+        mock_session = MagicMock()
+        with patch('services.reflection.MemoryService') as MockMemory, \
+             patch('services.reflection.AnalyticsService') as MockAnalytics:
+            memory_instance = MockMemory.return_value
+            analytics_instance = MockAnalytics.return_value
+
+            memory_instance.get_episodic_memory.return_value = [{"type": "action"}]
+            analytics_instance.calculate_fame_score.return_value = {
+                "engagement_proxy": 5.0,
+                "follower_delta": 2.0,
+            }
+
+            service = ReflectionService()
+            note = service.generate_reflection(mock_session)
+
+            memory_instance.add_improvement_note.assert_called_once_with(mock_session, note)
+            assert "Reviewed 1 actions" in note
+
+    def test_generate_reflection_no_activity(self):
+        mock_session = MagicMock()
+        with patch('services.reflection.MemoryService') as MockMemory, \
+             patch('services.reflection.AnalyticsService') as MockAnalytics:
+            memory_instance = MockMemory.return_value
+            analytics_instance = MockAnalytics.return_value
+
+            memory_instance.get_episodic_memory.return_value = []
+            analytics_instance.calculate_fame_score.return_value = {
+                "engagement_proxy": 0.0,
+                "follower_delta": 0.0,
+            }
+
+            service = ReflectionService()
+            note = service.generate_reflection(mock_session)
+
+            memory_instance.add_improvement_note.assert_called_once_with(mock_session, note)
+            assert "No recent activity" in note


### PR DESCRIPTION
## Summary
- add ReflectionService to analyze recent actions and fame metrics
- integrate reflection job into nightly scheduler
- test reflection note generation and no-activity handling

## Testing
- `PYTHONPATH=. pytest tests/test_reflection.py`
- `PYTHONPATH=. pytest` *(fails: TestOptimizer.test_beta_parameter_conversion, TestOptimizer.test_arm_combination_sampling, TestOptimizer.test_exploration_vs_exploitation, TestOptimizer.test_j_score_history_update, TestOptimizer.test_arm_recommendations, TestOptimizer.test_optimization_status, TestExperimentsService.test_arm_logging, TestExperimentsService.test_reward_updates, TestPersonaStore.test_file_change_detection, TestPersonaVersioning.test_persona_rollback, TestContentTemplates.test_proposal_template_completeness, TestContentTemplates.test_content_mutation, TestContentTemplates.test_quality_scoring, TestContentTemplates.test_end_to_end_generation)*

------
https://chatgpt.com/codex/tasks/task_e_68952eaa824883269f3dc0b21705e549