### PR TITLE
chore: configure vscode interpreter and paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "python.analysis.extraPaths": ["${workspaceFolder}"]
+}


### PR DESCRIPTION
## Summary
- point VS Code to project virtualenv and add root to PYTHONPATH

## Testing
- `pytest` *(fails: No module named 'numpy'; No module named 'services')*

------
https://chatgpt.com/codex/tasks/task_e_68953f76601c8326874f7aae3024e763