### PR TITLE
Handle WebSocket send failures

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,8 +111,15 @@ async def websocket_endpoint(websocket: WebSocket):
             # Use send_ping for WebSocket keep-alive
             try:
                 await websocket.send_text("ping")
-            except:
-                pass
+            except Exception:
+                # On send failure, remove connection and stop pinging
+                if websocket in websocket_connections:
+                    websocket_connections.remove(websocket)
+                try:
+                    await websocket.close()
+                except Exception:
+                    pass
+                break
     except WebSocketDisconnect:
         websocket_connections.remove(websocket)
         logger.info("WebSocket connection closed")


### PR DESCRIPTION
## Summary
- Remove broken WebSocket connections when ping send fails
- Close the failed socket and stop ping loop to prevent stale connections

## Testing
- `pytest` *(fails: No module named 'numpy', 'services', etc.)*
- `python - <<'PY'
import sys, types, time, asyncio
from fastapi.testclient import TestClient
runner_stub = types.ModuleType('runner')
runner_stub.get_uptime = lambda: 'test'
sys.modules['runner'] = runner_stub
from app import app, websocket_connections, broadcast_update
client = TestClient(app)
print('Initial connections:', len(websocket_connections))
with client.websocket_connect('/ws') as ws:
    print('After connect:', len(websocket_connections))
asyncio.run(broadcast_update({'msg': 'test'}))
print('After broadcast cleanup:', len(websocket_connections))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6895414c0f5483268d0decf4e260ef33