### PR TITLE
Fix duplicate toast listeners by running useEffect once

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -172,14 +172,16 @@ function useToast() {
   const [state, setState] = React.useState<State>(memoryState)
 
   React.useEffect(() => {
-    listeners.push(setState)
+    if (!listeners.includes(setState)) {
+      listeners.push(setState)
+    }
     return () => {
       const index = listeners.indexOf(setState)
       if (index > -1) {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- Ensure toast listener `setState` is only registered once on mount
- Avoid duplicate listener registrations during toast state changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `npx tsx test-toasts.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6895415b637883269dafee23d9cc4928