### PR TITLE
Use cross-db UUID defaults

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -4,8 +4,8 @@ SQLAlchemy models for DaLeoBanks database
 
 from sqlalchemy import Column, String, Integer, Float, DateTime, Boolean, JSON, Text
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.sql import func
 from datetime import datetime
+import uuid
 
 Base = declarative_base()
 
@@ -32,7 +32,7 @@ class Action(Base):
     """Action logs for all system activities"""
     __tablename__ = 'actions'
     
-    id = Column(String, primary_key=True, default=func.gen_random_uuid())
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     kind = Column(String, nullable=False)
     meta_json = Column(JSON)
     created_at = Column(DateTime, default=datetime.utcnow)
@@ -41,7 +41,7 @@ class KPI(Base):
     """KPI tracking over time"""
     __tablename__ = 'kpis'
     
-    id = Column(String, primary_key=True, default=func.gen_random_uuid())
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     name = Column(String, nullable=False)
     value = Column(Float, nullable=False)
     period_start = Column(DateTime, nullable=False)
@@ -51,7 +51,7 @@ class Note(Base):
     """Improvement notes and reflections"""
     __tablename__ = 'notes'
     
-    id = Column(String, primary_key=True, default=func.gen_random_uuid())
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     text = Column(Text, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
 
@@ -66,7 +66,7 @@ class Redirect(Base):
     """Tracked redirect links for revenue measurement"""
     __tablename__ = 'redirects'
     
-    id = Column(String, primary_key=True, default=func.gen_random_uuid())
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     label = Column(Text, nullable=False)
     target_url = Column(Text, nullable=False)
     utm = Column(Text)
@@ -77,7 +77,7 @@ class ArmsLog(Base):
     """Multi-armed bandit experiment logs"""
     __tablename__ = 'arms_log'
     
-    id = Column(String, primary_key=True, default=func.gen_random_uuid())
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     tweet_id = Column(String)
     post_type = Column(String, nullable=False)
     topic = Column(Text)

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,5 +1,4 @@
-import { sql } from "drizzle-orm";
-import { pgTable, text, varchar, integer, real, timestamp, boolean, json } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, varchar, integer, real, timestamp, boolean, json } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -21,14 +20,14 @@ export const tweets = pgTable("tweets", {
 });
 
 export const actions = pgTable("actions", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  id: uuid("id").defaultRandom().notNull().primaryKey(),
   kind: varchar("kind").notNull(),
   meta_json: json("meta_json"),
   created_at: timestamp("created_at").defaultNow(),
 });
 
 export const kpis = pgTable("kpis", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  id: uuid("id").defaultRandom().notNull().primaryKey(),
   name: varchar("name").notNull(),
   value: real("value").notNull(),
   period_start: timestamp("period_start").notNull(),
@@ -36,7 +35,7 @@ export const kpis = pgTable("kpis", {
 });
 
 export const notes = pgTable("notes", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  id: uuid("id").defaultRandom().notNull().primaryKey(),
   text: text("text").notNull(),
   created_at: timestamp("created_at").defaultNow(),
 });
@@ -47,7 +46,7 @@ export const followers_snapshot = pgTable("followers_snapshot", {
 });
 
 export const redirects = pgTable("redirects", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  id: uuid("id").defaultRandom().notNull().primaryKey(),
   label: text("label").notNull(),
   target_url: text("target_url").notNull(),
   utm: text("utm"),
@@ -56,7 +55,7 @@ export const redirects = pgTable("redirects", {
 });
 
 export const arms_log = pgTable("arms_log", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  id: uuid("id").defaultRandom().notNull().primaryKey(),
   tweet_id: varchar("tweet_id"),
   post_type: varchar("post_type").notNull(),
   topic: text("topic"),


### PR DESCRIPTION
## Summary
- use `uuid.uuid4()` for SQLAlchemy model IDs
- switch shared schema IDs to `uuid` columns with `defaultRandom`

## Testing
- `python - <<'PY' ...` (SQLite default test)
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres npm run db:push`
- `sudo -u postgres psql -d postgres -c "CREATE EXTENSION IF NOT EXISTS \"pgcrypto\"; INSERT INTO actions (kind) VALUES ('test'); SELECT id FROM actions ORDER BY created_at DESC LIMIT 1;"`
- `npm run check` *(fails: Property 'system_status' does not exist on type '{}')*
- `PYTHONPATH=. pytest` *(fails: assert 5 > 5)*

------
https://chatgpt.com/codex/tasks/task_e_6895415e7e0083269b77fa11098c8da7