### PR TITLE
Ensure database logging setup is idempotent

### DIFF
--- a/services/logging_utils.py
+++ b/services/logging_utils.py
@@ -110,10 +110,13 @@ class DatabaseLogHandler(logging.Handler):
 
 def setup_database_logging():
     """Set up database logging for warnings and errors"""
-    db_handler = DatabaseLogHandler()
-    
-    # Add to root logger
     root_logger = logging.getLogger()
+
+    # Prevent attaching multiple handlers during reloads
+    if any(isinstance(h, DatabaseLogHandler) for h in root_logger.handlers):
+        return
+
+    db_handler = DatabaseLogHandler()
     root_logger.addHandler(db_handler)
 
 class StructuredLogger:


### PR DESCRIPTION
## Summary
- avoid duplicate DatabaseLogHandler attachments by checking existing handlers in `setup_database_logging`

## Testing
- `PYTHONPATH=. pytest` *(fails: 14 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689541632fd48326a9f5b7663d6d68b0