### PR TITLE
Expose adaptive intensity and goal weight defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,18 @@ PORT=5000
 TIMEZONE=America/New_York
 
 # Operation Mode
-GOAL_MODE=FAME
-LIVE=true
+GOAL_MODE=IMPACT
+LIVE=false
+
+# Goal weights (alpha,beta,gamma,lambda)
+WEIGHTS_IMPACT=0.40,0.30,0.20,0.10
+WEIGHTS_REVENUE=0.30,0.55,0.25,0.25
+WEIGHTS_AUTHORITY=0.45,0.20,0.25,0.10
+WEIGHTS_FAME=0.65,0.15,0.25,0.20
+
+# Performance guardrails
+IMPACT_WEEKLY_FLOOR=10
+ADAPTIVE_INTENSITY=false
 
 # Optional: Quiet Hours (Eastern Time)
 # QUIET_HOURS_ET=1,6


### PR DESCRIPTION
## Summary
- add LIVE, goal weights, and guardrail settings to `.env.example`
- extend `Config` to load goal weights, adaptive intensity, and impact floor from env
- provide defaults for safety-first mode and expose parsed weights per goal

## Testing
- `pip install numpy`
- `pip install sqlalchemy pydantic python-Levenshtein`
- `pip install python-dotenv openai`
- `pip install tenacity`
- `PYTHONPATH=. pytest` *(fails: assertion failures in optimizer and templates tests)*

------
https://chatgpt.com/codex/tasks/task_e_68954363d7f483268d76350213c36992