### PR TITLE
Add goal modes and configuration validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,11 +202,11 @@ async def toggle_live_mode(request: ToggleRequest):
 
 @app.post("/api/mode")
 async def set_goal_mode(request: ModeRequest):
-    """Set goal mode (FAME/MONETIZE)"""
+    """Set goal mode"""
     try:
-        if request.mode not in ["FAME", "MONETIZE"]:
+        if request.mode not in config.GOAL_WEIGHTS:
             raise HTTPException(status_code=400, detail="Invalid mode")
-        
+
         config.GOAL_MODE = request.mode
         optimizer.update_goal_weights(request.mode)
         

--- a/config.py
+++ b/config.py
@@ -76,6 +76,18 @@ def get_config() -> Config:
             quiet_hours = [int(x) for x in os.getenv("QUIET_HOURS_ET", "").split(",")]
         except:
             quiet_hours = None
+
+    # Goal mode weights and validation
+    goal_weights = {
+        "FAME": {"alpha": 0.65, "beta": 0.15, "gamma": 0.25, "lambda": 0.20},
+        "MONETIZE": {"alpha": 0.30, "beta": 0.55, "gamma": 0.25, "lambda": 0.25},
+        "IMPACT": {"alpha": 0.40, "beta": 0.25, "gamma": 0.60, "lambda": 0.15},
+        "AUTHORITY": {"alpha": 0.35, "beta": 0.20, "gamma": 0.45, "lambda": 0.30},
+    }
+
+    goal_mode = os.getenv("GOAL_MODE", "FAME").upper()
+    if goal_mode not in goal_weights:
+        raise ValueError(f"Unknown GOAL_MODE: {goal_mode}")
     
     return Config(
         # Environment
@@ -93,8 +105,8 @@ def get_config() -> Config:
         ADMIN_TOKEN=os.getenv("ADMIN_TOKEN", "choose-a-long-random-string"),
         
         # Operation Mode
-        GOAL_MODE=os.getenv("GOAL_MODE", "FAME"),
-        LIVE=os.getenv("LIVE", "true").lower() == "true",
+        GOAL_MODE=goal_mode,
+        LIVE=os.getenv("LIVE", "false").lower() == "true",
         QUIET_HOURS_ET=quiet_hours,
         
         # Media settings
@@ -130,8 +142,5 @@ def get_config() -> Config:
         RAGEBAIT_GUARD=os.getenv("RAGEBAIT_GUARD", "on").lower() in ("on", "true", "1"),
         
         # Goal weights
-        GOAL_WEIGHTS={
-            "FAME": {"alpha": 0.65, "beta": 0.15, "gamma": 0.25, "lambda": 0.20},
-            "MONETIZE": {"alpha": 0.30, "beta": 0.55, "gamma": 0.25, "lambda": 0.25}
-        }
+        GOAL_WEIGHTS=goal_weights
     )

--- a/services/optimizer.py
+++ b/services/optimizer.py
@@ -38,6 +38,8 @@ class Optimizer:
         if goal_mode in self.config.GOAL_WEIGHTS:
             self.goal_weights = self.config.GOAL_WEIGHTS[goal_mode]
             logger.info(f"Updated goal weights for {goal_mode}: {self.goal_weights}")
+        else:
+            raise ValueError(f"Unknown goal mode: {goal_mode}")
     
     def get_action_weights(self) -> Dict[str, float]:
         """Get action weights based on current optimization state"""

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -128,6 +128,20 @@ class TestOptimizer:
         
         assert monetize_weights["beta"] > monetize_weights["alpha"]  # Revenue > Fame
         assert monetize_weights["beta"] == 0.55
+
+        # Test IMPACT mode
+        self.optimizer.update_goal_weights("IMPACT")
+        impact_weights = self.optimizer.goal_weights
+        assert impact_weights["gamma"] > impact_weights["alpha"]
+
+        # Test AUTHORITY mode
+        self.optimizer.update_goal_weights("AUTHORITY")
+        authority_weights = self.optimizer.goal_weights
+        assert authority_weights["lambda"] >= authority_weights["beta"]
+
+        # Invalid mode should raise
+        with pytest.raises(ValueError):
+            self.optimizer.update_goal_weights("UNKNOWN")
     
     def test_optimization_simulation(self):
         """Test optimization simulation for convergence"""


### PR DESCRIPTION
## Summary
- expand goal weights with IMPACT and AUTHORITY modes
- default LIVE mode to false and validate goal mode input
- adjust API and optimizer to handle invalid goal modes

## Testing
- `pytest -q` *(fails: missing attributes, failing assertions)*
- `PYTHONPATH=. pytest tests/test_optimizer.py::TestOptimizer::test_goal_weight_updates -q`

------
https://chatgpt.com/codex/tasks/task_e_6895436507fc8326a549a9ca90ab1d3b