### PR TITLE
Add guardrail tests and async analytics metrics retrieval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,6 @@ dependencies = [
 [tool.pytest.ini_options]
 pythonpath = ["."]
 testpaths = ["tests"]
+markers = [
+    "asyncio: mark test as using asyncio support",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+apscheduler==3.11.0
+fastapi==0.116.1
+levenshtein==0.27.1
+numpy==2.3.2
+openai==1.97.1
+psycopg2-binary==2.9.10
+pydantic==2.11.7
+python-dotenv==1.1.1
+python-multipart==0.0.20
+pyyaml==6.0.2
+sqlalchemy==2.0.42
+tenacity==9.1.2
+tweepy==4.16.0
+uvicorn==0.35.0
+websockets==15.0.1
+pytest==8.3.3

--- a/services/analytics.py
+++ b/services/analytics.py
@@ -32,8 +32,14 @@ class AnalyticsService:
             "quotes": 1.5
         }
     
-    def pull_and_update_metrics(self, session: Any, x_client) -> Dict[str, Any]:
-        """Pull latest metrics from X API and update database"""
+    async def pull_and_update_metrics(self, session: Any, x_client) -> Dict[str, Any]:
+        """Pull latest metrics from X API and update database.
+
+        The method is ``async`` because the underlying X client uses
+        asynchronous calls for fetching tweet metrics. This keeps the
+        scheduler coroutine-friendly and prevents blocking the event
+        loop while waiting on network operations.
+        """
         try:
             # Get recent tweets that need metric updates
             cutoff = datetime.utcnow() - timedelta(hours=6)
@@ -50,7 +56,7 @@ class AnalyticsService:
             tweet_ids = [tweet.id for tweet in tweets_to_update]
             
             # Fetch metrics from X API
-            metrics = x_client.metrics_for(tweet_ids)
+            metrics = await x_client.metrics_for(tweet_ids)
             
             updated_count = 0
             for tweet in tweets_to_update:

--- a/services/ethics_guard.py
+++ b/services/ethics_guard.py
@@ -106,10 +106,10 @@ class EthicsGuard:
         addendum = []
         
         if not has_uncertainty:
-            addendum.append("Uncertainty: Implementation complexity and user adoption rates may vary.")
-        
+            addendum.append("Uncertainty: Metrics may wobble; review weekly before scaling.")
+
         if not has_rollback:
-            addendum.append("Rollback: Revert to current system if KPIs not met within pilot period.")
+            addendum.append("Rollback: Revert to the prior system if KPIs miss for two weeks.")
         
         if addendum:
             # Add addendum to the text

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,47 @@
+"""Analytics calculations for J-score and impact weighting."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.analytics import AnalyticsService
+
+
+@pytest.mark.asyncio
+async def test_pull_metrics_no_client_returns_zero() -> None:
+    service = AnalyticsService()
+    session = MagicMock()
+    session.query.return_value.filter.return_value.all.return_value = []
+
+    result = await service.pull_and_update_metrics(session, x_client=None)
+
+    assert result == {"updated_count": 0}
+
+
+def test_calculate_impact_score_uses_config_weights() -> None:
+    service = AnalyticsService()
+    service.config.GOAL_WEIGHTS["IMPACT"] = {
+        "alpha": 1.0,
+        "beta": 2.0,
+        "gamma": 3.0,
+        "lambda": 0.0,
+    }
+
+    service.calculate_fame_score = MagicMock(
+        return_value={
+            "fame_score": 2.0,
+            "engagement_proxy": 0.0,
+            "follower_delta": 0.0,
+            "engagement_z": 0.0,
+            "follower_z": 0.0,
+        }
+    )
+    service.calculate_revenue_per_day = MagicMock(return_value=20.0)
+    service.calculate_authority_signals = MagicMock(return_value=15.0)
+
+    result = service.calculate_impact_score(MagicMock(), days=1)
+
+    expected = round(1.0 * 2.0 + 2.0 * (20.0 / 10.0) + 3.0 * (15.0 / 10.0), 2)
+    assert result["impact_score"] == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,49 @@
+"""Configuration defaults and safety checks."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import config as config_module
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove configuration-related environment variables for a clean test."""
+    for key in [
+        "LIVE",
+        "GOAL_MODE",
+        "WEIGHTS_IMPACT",
+        "WEIGHTS_REVENUE",
+        "WEIGHTS_AUTHORITY",
+        "WEIGHTS_FAME",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_live_defaults_to_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the agent ships with LIVE mode disabled by default."""
+    _clear_env(monkeypatch)
+    importlib.reload(config_module)
+    cfg = config_module.get_config()
+
+    assert cfg.LIVE is False
+    assert cfg.GOAL_MODE == "IMPACT"
+
+
+def test_goal_weights_have_impact_bias(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Weights in IMPACT mode should match the documented defaults."""
+    _clear_env(monkeypatch)
+    importlib.reload(config_module)
+    cfg = config_module.get_config()
+
+    impact_weights = cfg.GOAL_WEIGHTS["IMPACT"]
+    assert abs(impact_weights["alpha"] - 0.40) < 1e-6
+    assert abs(impact_weights["beta"] - 0.30) < 1e-6
+    assert abs(impact_weights["gamma"] - 0.20) < 1e-6
+    assert abs(impact_weights["lambda"] - 0.10) < 1e-6
+
+    # Ensure other modes exist for operator toggles.
+    for key in ("FAME", "REVENUE", "AUTHORITY", "MONETIZE"):
+        assert key in cfg.GOAL_WEIGHTS

--- a/tests/test_crisis.py
+++ b/tests/test_crisis.py
@@ -1,0 +1,32 @@
+"""Crisis detection heuristics."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from services.crisis import CrisisService
+
+
+def test_keyword_triggers_crisis() -> None:
+    service = CrisisService(sentiment_service=MagicMock())
+
+    assert service.is_crisis("This is a major scandal unfolding now") is True
+
+
+def test_negative_sentiment_triggers_crisis() -> None:
+    sentiment = MagicMock()
+    sentiment.analyze_sentiment.return_value = {"score": -0.9}
+
+    service = CrisisService(sentiment_service=sentiment)
+
+    assert service.is_crisis("Everything feels off") is True
+    sentiment.analyze_sentiment.assert_called_once()
+
+
+def test_positive_message_not_crisis() -> None:
+    sentiment = MagicMock()
+    sentiment.analyze_sentiment.return_value = {"score": 0.5}
+
+    service = CrisisService(sentiment_service=sentiment)
+
+    assert service.is_crisis("All systems stable") is False

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -230,7 +230,7 @@ class TestOptimizer:
         """Test that Thompson sampling respects epsilon floor"""
         # Even with very confident posterior, should still explore occasionally
         epsilon = 0.1
-        
+
         # Mock very confident performance data
         confident_performance = {
             "post_type": {
@@ -238,11 +238,13 @@ class TestOptimizer:
                 "question": {"mean_reward": 0.05, "count": 100}
             }
         }
-        
+
         # Over many samples, should still explore at least epsilon fraction
         exploration_count = 0
         total_samples = 100
-        
+
+        np.random.seed(42)
+
         # This is a conceptual test - in practice, epsilon enforcement
         # happens at the experiment service level
         for _ in range(total_samples):

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,106 @@
+"""Safety gates: receipts, tone, and citation validation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.generator import Generator
+from services.websearch import WebSearchService
+
+
+@pytest.fixture
+def generator_instance() -> Generator:
+    persona_store = MagicMock()
+    persona_store.get_current_persona.return_value = {
+        "templates": {
+            "tweet": "Problem → Mechanism → Pilot → KPIs → Risks → CTA",
+            "reply": "Acknowledge → Mechanism → Next step",
+        },
+        "tone_rules": {"people": "Kind."},
+    }
+    llm_adapter = AsyncMock()
+    return Generator(persona_store, llm_adapter)
+
+
+@pytest.fixture
+def empty_session() -> MagicMock:
+    session = MagicMock()
+    session.query.return_value.filter.return_value.all.return_value = []
+    return session
+
+
+@pytest.mark.asyncio
+async def test_proposal_requires_trusted_receipt(generator_instance: Generator, empty_session: MagicMock) -> None:
+    """Spicy proposals must include at least one trusted citation."""
+    proposal = (
+        "Problem: Coordination stalls.\n"
+        "Mechanism: Launch open pilot.\n"
+        "Pilot: 30-day sprint with 3 cities.\n"
+        "KPIs: 1) adoption>20% 2) NPS>50 3) rollback-ready.\n"
+        "Risks: adoption + compliance.\n"
+        "Rollback: Revert to manual intake if KPIs miss for 7 days.\n"
+        "CTA: Join: https://example.com/pilot"
+    )
+
+    result = await generator_instance._validate_and_refine(
+        proposal,
+        "proposal",
+        "governance",
+        empty_session,
+        intensity=3,
+    )
+
+    assert "error" in result
+    assert "citation" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_proposal_with_trusted_receipt_passes(generator_instance: Generator, empty_session: MagicMock) -> None:
+    proposal = (
+        "Problem: Coordination stalls.\n"
+        "Mechanism: Launch open pilot.\n"
+        "Pilot: 30-day sprint with 3 cities.\n"
+        "KPIs: 1) adoption>20% 2) NPS>50 3) rollback-ready.\n"
+        "Risks: adoption + compliance.\n"
+        "Rollback: Revert to manual intake if KPIs miss for 7 days.\n"
+        "CTA: Join: https://www.reuters.com/markets/pilot"
+    )
+
+    result = await generator_instance._validate_and_refine(
+        proposal,
+        "proposal",
+        "governance",
+        empty_session,
+        intensity=2,
+    )
+
+    assert "error" not in result
+    assert result["content_type"] == "proposal"
+
+
+@pytest.mark.asyncio
+async def test_reply_limited_to_two_sentences(generator_instance: Generator, empty_session: MagicMock) -> None:
+    reply = "One sentence. Second sentence! Third sentence?"
+
+    result = await generator_instance._validate_and_refine(
+        reply,
+        "reply",
+        "general",
+        empty_session,
+        intensity=1,
+    )
+
+    assert "error" in result
+    assert "two sentences" in result["error"].lower()
+
+
+def test_websearch_trusted_domain_detection() -> None:
+    service = WebSearchService()
+
+    trusted = "https://www.reuters.com/world"
+    untrusted = "https://blog.example.org/post"
+
+    assert service.has_valid_citation(f"Read more: {trusted}") is True
+    assert service.has_valid_citation(f"Sketchy: {untrusted}") is False

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -213,16 +213,16 @@ class TestContentTemplates:
     async def test_end_to_end_generation(self):
         """Test complete proposal generation pipeline"""
         # Mock LLM response
-        mock_response = """
-        Problem: Current DAO voting has 8% participation.
-        Mechanism: Implement conviction voting with delegation.
-        Pilot: 45-day trial with Aragon DAO, testing 5 proposals.
-        KPIs: 1) Participation >25%, 2) Quality score >3.5/5, 3) Gas efficiency >90%
-        Risks: Technical complexity, voter confusion, delegation attacks
-        Uncertainty: Adoption patterns may vary across different DAO types.
-        Rollback: Return to token voting if participation doesn't improve by day 30.
-        CTA: Join the pilot at aragon.org/conviction-voting
-        """
+        mock_response = (
+            "Problem:DAO turnout 8%. "
+            "Mechanism:CV pilot w/audits. "
+            "Pilot:45d,5 props. "
+            "KPIs:turnout>25%,quality>3.5,gas<90%. "
+            "Risks:complexity/confusion. "
+            "Uncertainty:small guilds may lag. "
+            "Rollback:revert if KPIs miss day30. "
+            "CTA:join https://reuters.com/technology/conviction-voting"
+        )
         
         self.mock_llm_adapter.chat.return_value = mock_response
         

--- a/tests/test_x_client.py
+++ b/tests/test_x_client.py
@@ -1,0 +1,161 @@
+"""Unit tests for the X client wrapper covering DM and media helpers."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# Provide a minimal tweepy stub so the client module can be imported without the
+# real dependency present in the test environment.
+class _TooManyRequests(Exception):
+    pass
+
+
+class _Paginator:
+    def __init__(self, *args, **kwargs):  # pragma: no cover - simple stub
+        self.args = args
+        self.kwargs = kwargs
+
+    def flatten(self, limit=None):  # pragma: no cover - simple stub
+        return []
+
+
+sys.modules.setdefault(
+    "tweepy",
+    types.SimpleNamespace(
+        Client=MagicMock,
+        TooManyRequests=_TooManyRequests,
+        Paginator=_Paginator,
+    ),
+)
+
+from services.x_client import XClient
+
+
+def _bind_async(method, instance):
+    return types.MethodType(method, instance)
+
+
+@pytest.mark.asyncio
+async def test_send_dm_respects_live_toggle(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = XClient()
+
+    captured = {}
+
+    async def fake_execute(
+        self,
+        *,
+        endpoint,
+        enabled,
+        live_required,
+        default_result,
+        func,
+        **kwargs,
+    ):
+        captured.update(
+            {
+                "endpoint": endpoint,
+                "enabled": enabled,
+                "live_required": live_required,
+            }
+        )
+        return default_result
+
+    monkeypatch.setattr(client, "_execute_write", _bind_async(fake_execute, client))
+
+    result = await client.send_dm("42", "hello")
+
+    assert result is True
+    assert captured["endpoint"] == "send_dm"
+    assert captured["enabled"] is True
+    # Default config has LIVE disabled, so the call should be a dry run.
+    assert captured["live_required"] is False
+
+
+@pytest.mark.asyncio
+async def test_send_dm_executes_when_live(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = XClient()
+    client.config.LIVE = True
+    client.config.ENABLE_DMS = True
+
+    class DummyClient:
+        def __init__(self):
+            self.calls = []
+
+        def send_direct_message(self, recipient_id: str, text: str):
+            self.calls.append((recipient_id, text))
+            return {"ok": True}
+
+    dummy = DummyClient()
+    client.client = dummy
+
+    async def fake_execute(
+        self,
+        *,
+        endpoint,
+        enabled,
+        live_required,
+        default_result,
+        func,
+        **kwargs,
+    ):
+        assert endpoint == "send_dm"
+        assert enabled is True
+        assert live_required is True
+        return func()
+
+    monkeypatch.setattr(client, "_execute_write", _bind_async(fake_execute, client))
+
+    result = await client.send_dm("123", "Value-first note")
+
+    assert result is True
+    assert dummy.calls == [("123", "Value-first note")]
+
+
+@pytest.mark.asyncio
+async def test_upload_media_supports_video(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    client = XClient()
+    client.config.LIVE = True
+    client.config.ENABLE_MEDIA = True
+
+    media_file = tmp_path / "clip.mp4"
+    media_file.write_bytes(b"fake")
+
+    class DummyClient:
+        def __init__(self):
+            self.categories = []
+
+        def media_upload(self, filename: str, media_category: str):
+            self.categories.append((filename, media_category))
+            response = MagicMock()
+            response.media_id_string = "9876543210"
+            return response
+
+    dummy = DummyClient()
+    client.client = dummy
+
+    async def fake_execute(
+        self,
+        *,
+        endpoint,
+        enabled,
+        live_required,
+        default_result,
+        func,
+        **kwargs,
+    ):
+        assert endpoint == "upload_media"
+        assert enabled is True
+        assert live_required is True
+        return func()
+
+    monkeypatch.setattr(client, "_execute_write", _bind_async(fake_execute, client))
+
+    media_id = await client.upload_media(str(media_file), media_type="video")
+
+    assert media_id == "9876543210"
+    # Ensure the X API receives the correct media category for video uploads.
+    assert dummy.categories[-1][1] == "tweet_video"


### PR DESCRIPTION
## Summary
- add a pinned `requirements.txt` for Replit deployment and register the pytest asyncio marker
- make the analytics metrics pull asynchronous so the scheduler can await the X client
- tighten the ethics addendum wording and expand the automated test suite for config defaults, safety gates, X client media/DM, analytics weights, and crisis detection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d0727a63dc83269b3bedb5fcce7475