### PR TITLE
Add shared config store and live toggle integration test

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from pydantic import BaseModel, ValidationError
 
-from config import get_config
+from config import get_config, update_config
 from db.session import init_db, get_db_session
 from db.models import *
 from services.persona_store import PersonaStore
@@ -214,7 +214,7 @@ async def set_crisis(request: CrisisRequest):
 async def toggle_live_mode(request: ToggleRequest):
     """Toggle LIVE mode on/off"""
     try:
-        config.LIVE = request.live
+        update_config(LIVE=request.live)
         
         # Broadcast update to clients
         await broadcast_update({
@@ -235,7 +235,7 @@ async def set_goal_mode(request: ModeRequest):
         if request.mode not in ["FAME", "MONETIZE"]:
             raise HTTPException(status_code=400, detail="Invalid mode")
         
-        config.GOAL_MODE = request.mode
+        update_config(GOAL_MODE=request.mode)
         optimizer.update_goal_weights(request.mode)
         
         await broadcast_update({

--- a/runner.py
+++ b/runner.py
@@ -13,7 +13,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
-from config import get_config
+from config import get_config, subscribe_to_updates
 from db.session import get_db_session, init_db
 from db.models import Action
 from services.multiplexer import SocialMultiplexer
@@ -54,6 +54,14 @@ self_model_service = SelfModelService(persona_store)
 optimizer = Optimizer()
 perception_service = PerceptionService()
 crisis_service = CrisisService()
+
+
+def _on_config_update(cfg, changes: Dict[str, Any]) -> None:
+    if "LIVE" in changes:
+        logger.info("Runner observed LIVE toggle -> %s", "on" if cfg.LIVE else "off")
+
+
+_unsubscribe = subscribe_to_updates(_on_config_update)
 
 async def start_scheduler():
     """Start the background scheduler"""

--- a/services/social_base.py
+++ b/services/social_base.py
@@ -36,6 +36,11 @@ class BaseSocialClient:
         self.enabled = enabled
         self.live = live
 
+    def set_live(self, live: bool) -> None:
+        """Update the live flag for the adapter."""
+
+        self.live = live
+
     async def publish(
         self,
         *,

--- a/tests/test_live_toggle.py
+++ b/tests/test_live_toggle.py
@@ -1,0 +1,71 @@
+import asyncio
+import importlib
+import sys
+import types
+
+
+def test_live_toggle_short_circuits_tweepy(monkeypatch):
+    calls = {"create": 0, "like": 0}
+
+    class DummyClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def get_me(self):
+            return types.SimpleNamespace()
+
+        def create_tweet(self, **kwargs):
+            calls["create"] += 1
+            return types.SimpleNamespace(data={"id": "tweet123"})
+
+        def like(self, tweet_id):
+            calls["like"] += 1
+            return True
+
+    class DummyPaginator:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def flatten(self, limit):
+            return []
+
+    tweepy_stub = types.SimpleNamespace(
+        TooManyRequests=Exception,
+        Client=DummyClient,
+        Paginator=lambda *args, **kwargs: DummyPaginator(),
+    )
+
+    monkeypatch.setitem(sys.modules, "tweepy", tweepy_stub)
+    monkeypatch.setenv("LIVE", "true")
+    monkeypatch.setenv("X_API_KEY", "key")
+    monkeypatch.setenv("X_API_SECRET", "secret")
+    monkeypatch.setenv("X_ACCESS_TOKEN", "token")
+    monkeypatch.setenv("X_ACCESS_SECRET", "access")
+    monkeypatch.setenv("X_BEARER_TOKEN", "bearer")
+
+    import config as config_module
+
+    importlib.reload(config_module)
+    config_module.reset_config()
+
+    monkeypatch.setattr("services.persona_store.PersonaStore.load_persona", lambda self: None)
+
+    for module_name in ["services.x_client", "services.multiplexer", "runner", "app"]:
+        sys.modules.pop(module_name, None)
+
+    import app as app_module
+
+    response = asyncio.run(
+        app_module.toggle_live_mode(app_module.ToggleRequest(live=False))
+    )
+    assert response["live"] is False
+
+    assert config_module.get_config().LIVE is False
+
+    tweet_id = asyncio.run(app_module.x_client.create_tweet("integration test"))
+    assert tweet_id == "dry_run_tweet_id"
+    assert calls["create"] == 0
+
+    liked = asyncio.run(app_module.x_client.like("12345"))
+    assert liked is True
+    assert calls["like"] == 0

--- a/tests/test_x_client.py
+++ b/tests/test_x_client.py
@@ -50,16 +50,16 @@ async def test_send_dm_respects_live_toggle(monkeypatch: pytest.MonkeyPatch) -> 
         *,
         endpoint,
         enabled,
-        live_required,
         default_result,
         func,
+        require_live=True,
         **kwargs,
     ):
         captured.update(
             {
                 "endpoint": endpoint,
                 "enabled": enabled,
-                "live_required": live_required,
+                "require_live": require_live,
             }
         )
         return default_result
@@ -72,7 +72,7 @@ async def test_send_dm_respects_live_toggle(monkeypatch: pytest.MonkeyPatch) -> 
     assert captured["endpoint"] == "send_dm"
     assert captured["enabled"] is True
     # Default config has LIVE disabled, so the call should be a dry run.
-    assert captured["live_required"] is False
+    assert captured["require_live"] is True
 
 
 @pytest.mark.asyncio
@@ -97,14 +97,14 @@ async def test_send_dm_executes_when_live(monkeypatch: pytest.MonkeyPatch) -> No
         *,
         endpoint,
         enabled,
-        live_required,
         default_result,
         func,
+        require_live=True,
         **kwargs,
     ):
         assert endpoint == "send_dm"
         assert enabled is True
-        assert live_required is True
+        assert require_live is True
         return func()
 
     monkeypatch.setattr(client, "_execute_write", _bind_async(fake_execute, client))
@@ -142,14 +142,14 @@ async def test_upload_media_supports_video(monkeypatch: pytest.MonkeyPatch, tmp_
         *,
         endpoint,
         enabled,
-        live_required,
         default_result,
         func,
+        require_live=True,
         **kwargs,
     ):
         assert endpoint == "upload_media"
         assert enabled is True
-        assert live_required is True
+        assert require_live is True
         return func()
 
     monkeypatch.setattr(client, "_execute_write", _bind_async(fake_execute, client))


### PR DESCRIPTION
## Summary
- add a singleton-style configuration store with listener support
- update posting services to observe shared live toggle state
- cover the live-mode API toggle with an integration test and align unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d093f5da3c832684cd9af9a8ccfc05