### PR TITLE
Incorporate penalty weighting into analytics J-scores

### DIFF
--- a/tests/test_jscore.py
+++ b/tests/test_jscore.py
@@ -6,3 +6,23 @@ def test_jscore_floor_gating():
     above = service.calculate_goal_aligned_j_score(impact=20, revenue=50, authority=30, fame=40)
     below = service.calculate_goal_aligned_j_score(impact=2, revenue=50, authority=30, fame=40)
     assert above > below
+
+
+def test_jscore_penalty_reduces_score():
+    service = AnalyticsService()
+    no_penalty = service.calculate_goal_aligned_j_score(
+        impact=30,
+        revenue=60,
+        authority=40,
+        fame=50,
+        penalty=0,
+    )
+    penalized = service.calculate_goal_aligned_j_score(
+        impact=30,
+        revenue=60,
+        authority=40,
+        fame=50,
+        penalty=10,
+    )
+
+    assert penalized < no_penalty


### PR DESCRIPTION
## Summary
- subtract config-driven penalty weight when calculating tweet-level and aggregate J-scores and return the latest penalty in analytics pulls
- reuse the analytics penalty calculator and lambda weight in KPI rollups so stored objective scores reflect infractions
- add coverage to ensure penalties lower the goal-aligned J-score

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0a0a022ec8326a6926b4556e51832