### PR TITLE
Require trusted sources for high-intensity outputs

### DIFF
--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -96,6 +96,96 @@ async def test_reply_limited_to_two_sentences(generator_instance: Generator, emp
     assert "two sentences" in result["error"].lower()
 
 
+@pytest.mark.asyncio
+async def test_high_intensity_reply_requires_whitelisted_domain(
+    generator_instance: Generator, empty_session: MagicMock
+) -> None:
+    spicy_reply = (
+        "Appreciate you flagging the gap in the rollout."
+        " Let's pilot the open data mechanism with weekly demos."
+        " Next step: share the metrics board, run weekly reviews, and cite https://example.com/benchmark"
+        " so leadership can align on accountability, transparency, and a shared timeline together."
+    )
+
+    result = await generator_instance._validate_and_refine(
+        spicy_reply,
+        "reply",
+        "general",
+        empty_session,
+        intensity=3,
+    )
+
+    assert "error" in result
+    assert "credible" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_high_intensity_reply_with_whitelisted_domain_passes(
+    generator_instance: Generator, empty_session: MagicMock
+) -> None:
+    trusted_reply = (
+        "Appreciate you flagging the gap in the rollout."
+        " Let's pilot the open data mechanism with weekly demos."
+        " Next step: share the metrics board, run weekly reviews, and cite https://www.reuters.com/technology"
+        " so leadership can align on accountability, transparency, and a shared timeline together."
+    )
+
+    result = await generator_instance._validate_and_refine(
+        trusted_reply,
+        "reply",
+        "general",
+        empty_session,
+        intensity=3,
+    )
+
+    assert "error" not in result
+    assert result["content_type"] == "reply"
+
+
+@pytest.mark.asyncio
+async def test_high_intensity_quote_requires_whitelisted_domain(
+    generator_instance: Generator, empty_session: MagicMock
+) -> None:
+    spicy_quote = (
+        "Coordination gaps compound quickly."
+        " Try the open data pilot so partners see momentum."
+        " Next step: benchmark against https://example.com/benchmark and publish results weekly to keep everyone aligned."
+    )
+
+    result = await generator_instance._validate_and_refine(
+        spicy_quote,
+        "quote",
+        "governance",
+        empty_session,
+        intensity=3,
+    )
+
+    assert "error" in result
+    assert "credible" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_high_intensity_quote_with_whitelisted_domain_passes(
+    generator_instance: Generator, empty_session: MagicMock
+) -> None:
+    trusted_quote = (
+        "Coordination gaps compound quickly."
+        " Try the open data pilot so partners see momentum."
+        " Next step: benchmark against https://www.reuters.com/technology and publish results weekly to keep everyone aligned."
+    )
+
+    result = await generator_instance._validate_and_refine(
+        trusted_quote,
+        "quote",
+        "governance",
+        empty_session,
+        intensity=3,
+    )
+
+    assert "error" not in result
+    assert result["content_type"] == "quote"
+
+
 def test_websearch_trusted_domain_detection() -> None:
     service = WebSearchService()
 


### PR DESCRIPTION
## Summary
- enforce a WebSearchService-backed citation requirement for all intensity ≥3 content and improve the guidance when requirements fail
- update the high-intensity reply evidence gate to demand whitelist citations explicitly
- add safety tests that cover whitelist pass/fail scenarios for high-intensity replies and quotes

## Testing
- pytest tests/test_safety.py tests/test_receipts.py

------
https://chatgpt.com/codex/tasks/task_e_68d0a1f48afc8326ad3246275413db9a