### PR TITLE
Capture mission signals in analytics impact scoring

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -48,6 +48,66 @@ class Action:
 
 
 @dataclass
+class PilotAcceptance:
+    """Records of pilots that were accepted by stakeholders."""
+
+    id: str = field(default_factory=_uuid)
+    pilot_name: str = ""
+    accepted_by: Optional[str] = None
+    scope: Optional[str] = None
+    accepted_at: datetime = field(default_factory=_utcnow)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ArtifactFork:
+    """Records of artifacts created or forked from agent outputs."""
+
+    id: str = field(default_factory=_uuid)
+    artifact_name: str = ""
+    source_url: Optional[str] = None
+    platform: Optional[str] = None
+    forked_at: datetime = field(default_factory=_utcnow)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CoalitionPartner:
+    """Organizations or individuals that joined coalition efforts."""
+
+    id: str = field(default_factory=_uuid)
+    partner_name: str = ""
+    partner_type: Optional[str] = None
+    joined_at: datetime = field(default_factory=_utcnow)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Citation:
+    """External citations attributed to the agent's work."""
+
+    id: str = field(default_factory=_uuid)
+    source_title: str = ""
+    url: Optional[str] = None
+    context: Optional[str] = None
+    cited_at: datetime = field(default_factory=_utcnow)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class HelpfulnessFeedback:
+    """Feedback captured about the agent's helpfulness."""
+
+    id: str = field(default_factory=_uuid)
+    channel: str = ""
+    rating: float = 0.0
+    comment: Optional[str] = None
+    reference_id: Optional[str] = None
+    captured_at: datetime = field(default_factory=_utcnow)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
 class KPI:
     """KPI tracking over time."""
 
@@ -130,6 +190,11 @@ __all__ = [
     "Tweet",
     "Action",
     "KPI",
+    "PilotAcceptance",
+    "ArtifactFork",
+    "CoalitionPartner",
+    "Citation",
+    "HelpfulnessFeedback",
     "Note",
     "FollowersSnapshot",
     "Redirect",

--- a/tests/test_jscore.py
+++ b/tests/test_jscore.py
@@ -1,4 +1,5 @@
 from services.analytics import AnalyticsService
+from db.models import Tweet
 
 
 def test_jscore_floor_gating():
@@ -26,3 +27,15 @@ def test_jscore_penalty_reduces_score():
     )
 
     assert penalized < no_penalty
+
+
+def test_tweet_jscore_includes_mission_alignment():
+    service = AnalyticsService()
+    tweet = Tweet(id="1", text="example", kind="proposal")
+    tweet.likes = 10
+    tweet.rts = 2
+    tweet.replies = 1
+    high_alignment = service._calculate_j_score(tweet, mission_alignment=1.0)
+    low_alignment = service._calculate_j_score(tweet, mission_alignment=0.0)
+
+    assert high_alignment > low_alignment


### PR DESCRIPTION
## Summary
- add dedicated data models for pilot acceptances, artifact forks, coalition partners, citations, and helpfulness feedback
- extend the analytics service to persist structured action outcomes, derive mission-aligned impact scores, and fold the signals into J-score calculations
- update runner jobs to emit structured metadata for actions so the new analytics pipelines are populated, and refresh unit tests around impact aggregation and mission weighting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e140a319f08326ac73c00f742ce43d