### PR TITLE
Add thread generation workflow and DM scheduler coverage

### DIFF
--- a/services/persona_store.py
+++ b/services/persona_store.py
@@ -30,6 +30,7 @@ class PersonaSchema:
     templates: Dict[str, Any]
     prompt_overrides: Optional[Dict[str, str]] = None
     intensity_settings: Optional[Dict[str, Any]] = None
+    engagement_focus: Optional[List[str]] = None
 
     _validators: Dict[str, Callable[["PersonaSchema"], None]] = field(init=False, repr=False, default_factory=dict)
 
@@ -70,6 +71,7 @@ class PersonaSchema:
             "templates": deepcopy(self.templates),
             "prompt_overrides": deepcopy(self.prompt_overrides),
             "intensity_settings": deepcopy(self.intensity_settings),
+            "engagement_focus": deepcopy(self.engagement_focus),
         }
         return data
 

--- a/tests/test_generator_thread.py
+++ b/tests/test_generator_thread.py
@@ -1,0 +1,87 @@
+import json
+
+import pytest
+
+from db.session import init_db
+from services.generator import Generator
+from services.persona_store import PersonaStore
+
+
+class StubLLM:
+    def __init__(self, payload):
+        self.payload = payload
+
+    async def chat(self, *, system, messages, temperature):  # noqa: D401 - simple stub
+        return json.dumps(self.payload)
+
+
+@pytest.mark.asyncio
+async def test_make_thread_returns_valid_posts(monkeypatch):
+    init_db()
+
+    payload = {
+        "posts": [
+            {
+                "text": "1/ Systemic issue with receipts https://www.reuters.com/example. Next step: convene the pilot.",
+                "media": {"path": "image.png", "type": "image", "alt": "chart"},
+            },
+            {
+                "text": "2/ Mechanism and next step https://www.reuters.com/followup",
+            },
+        ],
+        "dm_copy": "Sharing a follow-up with receipts https://www.reuters.com/followup",
+    }
+
+    persona = PersonaStore()
+    generator = Generator(persona, StubLLM(payload))
+
+    result = await generator.make_thread(topic="coordination", intensity=3)
+
+    assert "error" not in result
+    assert len(result["posts"]) == 2
+    first_media = result["posts"][0]["media"][0]
+    assert first_media["path"] == "image.png"
+    assert first_media["type"] == "image"
+    assert "dm_copy" in result and "follow-up" in result["dm_copy"]
+
+
+@pytest.mark.asyncio
+async def test_make_thread_requires_citation_at_high_intensity(monkeypatch):
+    init_db()
+
+    payload = {
+        "posts": [
+            {"text": "1/ Strong claim without link. Next step: invite partners."},
+        ],
+    }
+
+    persona = PersonaStore()
+    generator = Generator(persona, StubLLM(payload))
+
+    result = await generator.make_thread(topic="policy", intensity=3, include_dm=False)
+
+    assert "error" in result
+    assert "credible" in result["details"]["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_make_dm_copy_trims_and_respects_guardrails(monkeypatch):
+    init_db()
+
+    class DMStub:
+        async def chat(self, *, system, messages, temperature):
+            return "Offering a helpful resource on coordination with trusted data."
+
+    persona = PersonaStore()
+    generator = Generator(persona, DMStub())
+
+    dm = await generator.make_dm_copy(
+        "Highlight the coalition opportunity.",
+        topic="energy",
+        recipient={"username": "ally"},
+        intensity=2,
+    )
+
+    assert "error" not in dm
+    assert dm["content"].startswith("Offering a helpful resource")
+    assert dm["recipient"]["username"] == "ally"

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -43,3 +43,55 @@ async def test_multiplexer_returns_dry_run_ids(monkeypatch):
     assert results["linkedin"].post_id.startswith("linkedin:post/md_dry_")
     assert results["mastodon"].dry_run is True
     assert results["mastodon"].post_id.startswith("mastodon:post/md_dry_")
+
+
+class MediaStubXClient:
+    def __init__(self):
+        self.uploads = []
+        self.tweets = []
+
+    async def upload_media(self, media_path: str, media_type: str = "image"):
+        self.uploads.append((media_path, media_type))
+        return "media123"
+
+    async def create_tweet(self, text, quote_tweet_id=None, in_reply_to=None, media_ids=None, idempotency_key=None):
+        self.tweets.append({
+            "text": text,
+            "quote_tweet_id": quote_tweet_id,
+            "in_reply_to": in_reply_to,
+            "media_ids": media_ids,
+            "idempotency_key": idempotency_key,
+        })
+        return "tweet456"
+
+
+@pytest.mark.asyncio
+async def test_multiplexer_uploads_media_before_post(monkeypatch):
+    config = get_config()
+    previous_live = config.LIVE
+    config.LIVE = True
+
+    x_client = MediaStubXClient()
+
+    multiplexer = SocialMultiplexer(
+        config=config,
+        x_client=x_client,
+    )
+
+    metadata = {
+        "media": [{"path": "sample.png", "type": "image"}],
+        "idempotency_key": "abc123",
+    }
+
+    results = await multiplexer.publish(
+        "Testing media upload",
+        kind="post",
+        metadata=metadata,
+    )
+
+    config.LIVE = previous_live
+
+    assert x_client.uploads == [("sample.png", "image")]
+    assert x_client.tweets[0]["media_ids"] == ["media123"]
+    assert results["x"].dry_run is False
+    assert results["x"].post_id == "tweet456"

--- a/tests/test_runner_jobs.py
+++ b/tests/test_runner_jobs.py
@@ -1,0 +1,113 @@
+import types
+
+import pytest
+
+import runner
+from db.models import Action, Tweet
+from db.session import get_db_session, init_db
+from services.social_base import SocialPostResult
+
+
+@pytest.mark.asyncio
+async def test_publish_thread_job_records_posts(monkeypatch):
+    init_db()
+
+    publish_calls = []
+
+    async def fake_publish(content, *, kind, intensity, in_reply_to, metadata, quote_to=None):
+        publish_calls.append({
+            "content": content,
+            "in_reply_to": in_reply_to,
+            "metadata": metadata,
+        })
+        index = len(publish_calls)
+        return {
+            "x": SocialPostResult(platform="x", post_id=f"id{index}", dry_run=False, meta=metadata)
+        }
+
+    async def fake_decide():
+        return {"type": "POST_THREAD", "topic": "energy", "intensity": 3}
+
+    async def fake_make_thread(topic, intensity):
+        return {
+            "posts": [
+                {"content": "Segment one https://www.reuters.com/a", "media": []},
+                {"content": "Segment two https://www.reuters.com/b", "media": []},
+            ],
+            "dm_copy": "DM preview",
+        }
+
+    monkeypatch.setattr(runner.crisis_service, "guard", lambda action: True)
+    monkeypatch.setattr(runner.selector, "decide_next_action", fake_decide)
+    monkeypatch.setattr(runner.generator, "make_thread", fake_make_thread)
+    monkeypatch.setattr(runner, "multiplexer", types.SimpleNamespace(publish=fake_publish))
+
+    previous_live = runner.config.LIVE
+    runner.config.LIVE = True
+
+    await runner.publish_thread_job()
+
+    runner.config.LIVE = previous_live
+
+    assert len(publish_calls) == 2
+    assert publish_calls[0]["in_reply_to"] is None
+    assert publish_calls[1]["in_reply_to"] == "id1"
+    assert publish_calls[0]["metadata"]["thread_index"] == 0
+
+    with get_db_session() as session:
+        tweets = session.query(Tweet).all()
+        actions = session.query(Action).all()
+
+    assert {tweet.kind for tweet in tweets} == {"thread_root", "thread_segment"}
+    assert any(action.kind == "thread_published" for action in actions)
+
+
+@pytest.mark.asyncio
+async def test_value_dm_job_respects_live_toggle(monkeypatch):
+    init_db()
+
+    send_calls = []
+    mark_calls = []
+
+    class DMClient:
+        def is_healthy(self):
+            return True
+
+        async def send_dm(self, user_id, text):
+            send_calls.append((user_id, text))
+            return True
+
+    async def fake_decide():
+        return {
+            "type": "SEND_VALUE_DM",
+            "recipient": {"username": "ally", "topics": ["energy"], "id": "42"},
+            "intensity": 2,
+        }
+
+    async def fake_dm_copy(seed, *, topic, recipient, intensity):
+        return {"content": "Helpful DM", "recipient": recipient, "topic": topic, "intensity": intensity}
+
+    monkeypatch.setattr(runner.crisis_service, "guard", lambda action: True)
+    monkeypatch.setattr(runner.selector, "decide_next_action", fake_decide)
+    monkeypatch.setattr(runner.selector, "mark_dm_sent", lambda target_id: mark_calls.append(target_id))
+    monkeypatch.setattr(runner.generator, "make_dm_copy", fake_dm_copy)
+    monkeypatch.setattr(runner, "x_client", DMClient())
+
+    previous_live = runner.config.LIVE
+    previous_enable = runner.config.ENABLE_DMS
+    runner.config.LIVE = False
+    runner.config.ENABLE_DMS = True
+
+    await runner.value_dm_job()
+
+    runner.config.LIVE = previous_live
+    runner.config.ENABLE_DMS = previous_enable
+
+    with get_db_session() as session:
+        actions = session.query(Action).all()
+
+    assert send_calls == []
+    assert mark_calls == []
+    drafted_actions = [a for a in actions if a.kind == "value_dm_drafted"]
+    assert drafted_actions, "Expected drafted DM action"
+    assert drafted_actions[0].meta_json.get("dry_run") is True


### PR DESCRIPTION
## Summary
- add generator support for persona-aware thread creation and value-first DM copy
- enable media-aware publishing through the X adapter and schedule new thread/DM jobs
- extend selector, perception, and persona schema plus new tests covering generator, multiplexer, and runner flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3080476ac8326b7345741147e5db7