### PR TITLE
Add security guardrails and request observability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ tweepy==4.16.0
 uvicorn==0.35.0
 websockets==15.0.1
 pytest==8.3.3
+PyJWT==2.10.1
+prometheus-client==0.21.1

--- a/services/observability.py
+++ b/services/observability.py
@@ -1,0 +1,55 @@
+"""Request observability: structured logging hooks and Prometheus metrics."""
+from typing import Optional
+import time
+
+from fastapi import APIRouter, Request
+from fastapi.responses import Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+
+request_counter = Counter(
+    "app_http_requests_total",
+    "Total HTTP requests",
+    ["method", "path", "status", "role"],
+)
+
+request_latency = Histogram(
+    "app_http_request_duration_seconds",
+    "HTTP request latency",
+    ["method", "path", "role"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2, 5),
+)
+
+external_call_outcomes = Counter(
+    "app_external_call_outcomes_total",
+    "External call outcomes",
+    ["system", "result"],
+)
+
+metrics_router = APIRouter()
+
+
+@metrics_router.get("/metrics")
+async def metrics_endpoint():
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+def record_request_metrics(request: Request, status_code: int, duration: float, role: str):
+    path = request.url.path
+    method = request.method
+    role_label = role or "anonymous"
+    request_counter.labels(method=method, path=path, status=str(status_code), role=role_label).inc()
+    request_latency.labels(method=method, path=path, role=role_label).observe(duration)
+
+
+def record_external_call(system: str, result: str):
+    external_call_outcomes.labels(system=system, result=result).inc()
+
+
+def request_timer() -> float:
+    return time.perf_counter()
+
+
+def elapsed(start_time: Optional[float]) -> float:
+    if start_time is None:
+        return 0.0
+    return time.perf_counter() - start_time

--- a/services/security.py
+++ b/services/security.py
@@ -1,0 +1,130 @@
+"""Security utilities: JWT auth, allowlists, and per-role rate limiting."""
+from dataclasses import dataclass
+from datetime import datetime, UTC, timedelta
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+import jwt
+from fastapi import Depends, HTTPException, Request, status
+
+from config import get_config
+from services.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+def _parse_roles(claims: Dict[str, object]) -> List[str]:
+    roles: List[str] = []
+    raw_roles = claims.get("roles") or claims.get("role")
+    if isinstance(raw_roles, list):
+        roles = [str(r).lower() for r in raw_roles]
+    elif isinstance(raw_roles, str):
+        roles = [raw_roles.lower()]
+    return roles or ["user"]
+
+
+def _client_ip(request: Request) -> str:
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    if request.client:
+        return request.client.host
+    return "unknown"
+
+
+@dataclass
+class RequestContext:
+    request_id: str
+    subject: str
+    roles: List[str]
+    client_ip: str
+
+
+class RoleRateLimiter:
+    """Simple in-memory per-role limiter using sliding window."""
+
+    def __init__(self, limits: Dict[str, int], window_seconds: int = 60):
+        self.limits = limits
+        self.window_seconds = window_seconds
+        self.history: Dict[str, List[datetime]] = {}
+
+    def allow(self, role: str, key: str) -> bool:
+        limit = self.limits.get(role, self.limits.get("default"))
+        if not limit:
+            return True
+
+        now = datetime.now(UTC)
+        window_start = now - timedelta(seconds=self.window_seconds)
+        bucket = self.history.setdefault(key, [])
+        # drop stale
+        self.history[key] = [ts for ts in bucket if ts > window_start]
+        if len(self.history[key]) >= limit:
+            return False
+        self.history[key].append(now)
+        return True
+
+
+_config = get_config()
+role_limiter = RoleRateLimiter(_config.ROLE_RATE_LIMITS, window_seconds=_config.ROLE_RATE_LIMIT_WINDOW)
+
+
+def get_request_context(request: Request) -> RequestContext:
+    config = get_config()
+    req_id = request.headers.get(config.REQUEST_ID_HEADER, str(uuid4()))
+    client_ip = _client_ip(request)
+
+    if config.ALLOWED_IPS and client_ip not in config.ALLOWED_IPS:
+        logger.warning("Blocked request from disallowed IP", extra_data={"client_ip": client_ip, "path": request.url.path})
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="IP not allowed")
+
+    auth_header = request.headers.get("authorization")
+    subject = "anonymous"
+    roles: List[str] = ["anonymous"]
+
+    if auth_header and auth_header.lower().startswith("bearer "):
+        token = auth_header.split(" ", 1)[1]
+        try:
+            claims = jwt.decode(
+                token,
+                config.JWT_SECRET,
+                algorithms=["HS256"],
+                audience=config.JWT_AUDIENCE,
+                issuer=config.JWT_ISSUER or None,
+                options={"verify_aud": bool(config.JWT_AUDIENCE)},
+            )
+            subject = str(claims.get("sub", subject))
+            roles = _parse_roles(claims)
+        except Exception as exc:
+            logger.warning("JWT validation failed", extra_data={"error": str(exc)})
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    context = RequestContext(request_id=req_id, subject=subject, roles=roles, client_ip=client_ip)
+    request.state.request_context = context
+    return context
+
+
+def require_role(required_role: str):
+    async def dependency(context: RequestContext = Depends(get_request_context)) -> RequestContext:
+        if required_role not in context.roles:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient role")
+
+        limiter_key = f"{required_role}:{context.client_ip or context.subject}"
+        if not role_limiter.allow(required_role, limiter_key):
+            raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Rate limit exceeded for role")
+        return context
+
+    return dependency
+
+
+def require_any_role(roles: List[str]):
+    async def dependency(context: RequestContext = Depends(get_request_context)) -> RequestContext:
+        if not any(role in context.roles for role in roles):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient role")
+
+        limiter_key = f"{','.join(sorted(context.roles))}:{context.client_ip or context.subject}"
+        dominant_role = next((role for role in roles if role in context.roles), roles[0])
+        if not role_limiter.allow(dominant_role, limiter_key):
+            raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Rate limit exceeded for role")
+        return context
+
+    return dependency


### PR DESCRIPTION
## Summary
- add JWT-based role enforcement, IP allowlist checks, and per-role rate limiting with contextual request IDs
- extend configuration for security controls and register Prometheus metrics endpoint with structured validation responses
- introduce reusable security and observability helpers for FastAPI and gateway layers

## Testing
- python -m compileall app.py services/security.py services/observability.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949363f47a48326bdcccd7ade21243a)