### PR TITLE
Fix Replit boot: force pip into venv, self-repair partial npm installs

### DIFF
--- a/.replit
+++ b/.replit
@@ -35,7 +35,7 @@ waitForPort = 5000
 # bundle and pre-installs Python deps so the run step boots fast enough
 # for the deployment health check.
 [deployment]
-build = ["bash", "-c", "npm ci && npm run build && python3 -m venv venv && ./venv/bin/pip install -r requirements.txt"]
+build = ["bash", "-c", "npm ci && npm run build && python3 -m venv venv && PIP_USER=0 ./venv/bin/pip install -r requirements.txt"]
 run = ["bash", "scripts/replit-deploy.sh"]
 deploymentTarget = "vm"
 

--- a/scripts/replit-deploy.sh
+++ b/scripts/replit-deploy.sh
@@ -5,6 +5,10 @@
 # the bundled production server (Express serving dist/public + FastAPI).
 set -euo pipefail
 
+# Replit's base environment configures pip for --user installs, which is
+# incompatible with a virtualenv. Force installs into the venv.
+export PIP_USER=0
+
 if [ ! -d "venv" ]; then
   python3 -m venv venv
 fi

--- a/scripts/replit-start.sh
+++ b/scripts/replit-start.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Replit's base environment configures pip for --user installs, which is
+# incompatible with a virtualenv (pip aborts with "Can not perform a
+# '--user' install"). Force installs into the venv.
+export PIP_USER=0
+
 # Install Python dependencies if needed
 if [ ! -d "venv" ]; then
   python3 -m venv venv
@@ -9,8 +14,9 @@ source venv/bin/activate
 pip install --upgrade pip >/dev/null
 pip install -r requirements.txt >/dev/null
 
-# Install Node dependencies (idempotent)
-if [ ! -d "node_modules" ]; then
+# Install Node dependencies. Check for the tsx binary rather than the
+# node_modules folder so an interrupted install self-repairs on next run.
+if [ ! -x "node_modules/.bin/tsx" ]; then
   npm install >/dev/null
 fi
 

--- a/self_model_card.md
+++ b/self_model_card.md
@@ -1,6 +1,6 @@
 # Self-Model Card: DaLeoBanks
 
-**Generated:** 2026-07-02 11:50:11 UTC
+**Generated:** 2026-07-02 16:55:26 UTC
 **Identity Hash:** `935e2e73ffe0cd8f`  
 **Version:** 3
 
@@ -55,7 +55,7 @@ Challenge → Analyze → Propose → Inspire
 ## Operational Metadata
 
 - **Configuration File:** `persona.json`
-- **Last Modified:** 2026-07-02 11:50:11 UTC
+- **Last Modified:** 2026-07-02 16:55:26 UTC
 - **Verification Hash:** `935e2e73ffe0cd8f`
 
 ## Change Log


### PR DESCRIPTION
## Summary

Commits the two Replit boot fixes that were applied and verified directly in the workspace, so fresh imports and redeploys carry them (until now they existed only as uncommitted workspace edits — any `git reset` or re-import reverted to the crashing versions, which is exactly how the "Full Stack" workflow crash reproduced):

- **`PIP_USER=0`** exported in `scripts/replit-start.sh` and `scripts/replit-deploy.sh`, and inlined into the `.replit` deployment build command. Replit's base environment configures pip for `--user` installs, which a virtualenv rejects ("Can not perform a '--user' install"), crashing the Python install step — including the Reserved VM publish build.
- **tsx self-repair**: the start script now checks for the actual `node_modules/.bin/tsx` binary instead of the `node_modules` folder, so a partially completed npm install (left behind by the first failed boot) is repaired on the next run instead of crashing `npm run dev`.

## Testing
- `bash -n` on both scripts; `.replit` parses as valid TOML
- `python -m pytest` — 117 passed
- Local dev boot (`npm run dev`) verified working with and without `REPL_ID` set (Replit-simulated path); frontend and proxied `/api/health` return 200
- The `PIP_USER` failure and fix were confirmed on actual Replit by the repo owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnM7HbkV5ouKu3WST9v7fW

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnM7HbkV5ouKu3WST9v7fW)_