### PR TITLE
Add dream consolidation: idle-hours memory sharpening

### DIFF
--- a/docs/SAFETY_AND_ROLLOUT.md
+++ b/docs/SAFETY_AND_ROLLOUT.md
@@ -29,8 +29,9 @@ Events currently chained: `startup`, `publish_attempt` / `publish_gated` /
 `breaker_tripped` / `breaker_reset` (heartbeat), `armed` / `arm_refused`
 (arming ceremony), `dm_received` (metadata only — never private text),
 `revenue_event` / `link_click`, `discovery_proposal` /
-`discovery_decision`, `okr_proposal` / `okr_decision`, and
-`constitution_hash` / `constitution_tampered` / `constitution_missing`.
+`discovery_decision`, `okr_proposal` / `okr_decision`, `memory_consolidated` (dream
+consolidation), and `constitution_hash` / `constitution_tampered` /
+`constitution_missing`.
 
 The app verifies the chain at startup (`app.py`); a broken chain disarms
 live mode before anything can act.

--- a/replit.md
+++ b/replit.md
@@ -146,6 +146,7 @@ The architecture prioritizes modularity, safety, and autonomous operation while 
 - **Measured revenue**: `POST /api/conversions` records real revenue events; revenue KPIs prefer conversions over the legacy click estimate.
 - **Gated discovery**: daily job proposes new voices/keywords from real engagement; `POST /api/discoveries/{id}/decision` approves; only approvals widen perception.
 - **Constitution**: `constitution.md` hashed into the ledger at startup, re-verified nightly (drift disarms). Planner files OKR changes as `GoalProposal`s, applied only after `POST /api/goals/proposals/{id}/decision` approval.
+- **Dream consolidation**: a daily idle-hours job clusters near-duplicate lessons (same embedding as the semantic index) and merges each cluster into one sharper lesson via the LLM, with a deterministic keep-newest fallback; every compression is ledgered as `memory_consolidated`.
 
 ### Testing
 - `python -m pytest` (150 tests) and `npm run check` must pass; `tests/stubs/` provides offline fallbacks for third-party packages.

--- a/runner.py
+++ b/runner.py
@@ -32,6 +32,7 @@ from services.logging_utils import get_logger
 from services.crisis import CrisisService
 from services.memory import MemoryService
 from services.perception import PerceptionService
+from services.consolidation import ConsolidationService
 from services.constitution import ConstitutionGuard
 from services.critic import Critic
 from services.ethics_guard import EthicsGuard
@@ -71,6 +72,7 @@ thought_interpreter = ThoughtInterpreter(
 )
 heartbeat = Heartbeat(get_kill_switch(), get_ledger())
 constitution_guard = ConstitutionGuard(ledger=get_ledger(), kill_switch=get_kill_switch())
+consolidation_service = ConsolidationService(llm_adapter, ledger=get_ledger())
 
 # Track pagination cursors for perception ingest to avoid refetching.
 _perception_state: Dict[str, Any] = {}
@@ -231,6 +233,14 @@ async def _add_jobs():
         heartbeat.supervise('discovery', discovery_job),
         CronTrigger(hour=6),
         id='discovery',
+        max_instances=1
+    )
+
+    # Dream consolidation: merge near-duplicate lessons while idle
+    scheduler.add_job(
+        heartbeat.supervise('dream_consolidation', dream_consolidation_job),
+        CronTrigger(hour=5),
+        id='dream_consolidation',
         max_instances=1
     )
     
@@ -1083,6 +1093,17 @@ async def nightly_reflection_job():
 
     except Exception as e:
         logger.error(f"Nightly reflection job failed: {e}")
+
+async def dream_consolidation_job():
+    """Merge near-duplicate lessons into sharper ones during idle hours."""
+    try:
+        with get_db_session() as session:
+            result = await consolidation_service.consolidate(session)
+        if result.get("clusters_merged"):
+            logger.info(f"Dream consolidation: {result}")
+    except Exception as e:
+        logger.error(f"Dream consolidation job failed: {e}")
+
 
 async def weekly_planning_job():
     """Perform weekly planning and update OKRs"""

--- a/services/consolidation.py
+++ b/services/consolidation.py
@@ -1,0 +1,132 @@
+"""Dream consolidation: digital sleep that sharpens the agent's memory.
+
+Over time the improvement-note store accumulates near-duplicate lessons
+("post energy proposals earlier", "energy posts perform better in the
+morning", ...). During idle hours this service clusters similar notes using
+the same hashed bag-of-words embedding the semantic index uses, asks the LLM
+to merge each cluster into one sharper lesson, and replaces the originals.
+Every compression is recorded in the decision ledger, so consolidation is
+auditable, and the LLM path degrades to a deterministic fallback (keep the
+newest note of the cluster) so sleep can never corrupt memory.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from db.models import Note
+from services.ledger import DecisionLedger
+from services.logging_utils import get_logger
+from services.semantic_index import _cosine, _embed
+
+logger = get_logger(__name__)
+
+
+class ConsolidationService:
+    """Clusters near-duplicate lessons and merges each cluster into one."""
+
+    def __init__(
+        self,
+        llm_adapter: Any = None,
+        *,
+        ledger: Optional[DecisionLedger] = None,
+        similarity_threshold: float = 0.6,
+        dimensions: int = 4096,
+    ) -> None:
+        self.llm = llm_adapter
+        self.ledger = ledger or DecisionLedger()
+        self.similarity_threshold = similarity_threshold
+        self.dimensions = dimensions
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+    async def consolidate(self, session: Any) -> Dict[str, Any]:
+        """Run one consolidation pass. Returns a summary of what merged."""
+        notes = (
+            session.query(Note)
+            .order_by(lambda n: n.created_at)
+            .all()
+        )
+        clusters = self._cluster(notes)
+        merge_clusters = [c for c in clusters if len(c) >= 2]
+        if not merge_clusters:
+            return {"clusters_merged": 0, "notes_removed": 0}
+
+        removed = 0
+        for cluster in merge_clusters:
+            merged_text = await self._merge_cluster([n.text for n in cluster])
+            if not merged_text:
+                # Deterministic fallback: the newest note survives.
+                merged_text = cluster[-1].text
+
+            for note in cluster:
+                session.delete(note)
+            session.add(Note(text=merged_text))
+            removed += len(cluster) - 1
+
+            self.ledger.record("memory_consolidated", {
+                "cluster_size": len(cluster),
+                "merged_into": merged_text[:200],
+            })
+
+        session.commit()
+        logger.info(
+            "Dream consolidation merged %d clusters (%d notes removed)",
+            len(merge_clusters), removed,
+        )
+        return {"clusters_merged": len(merge_clusters), "notes_removed": removed}
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+    def _cluster(self, notes: List[Note]) -> List[List[Note]]:
+        """Greedy similarity clustering over the notes, oldest first."""
+        vectors = [_embed(note.text, self.dimensions) for note in notes]
+        clusters: List[List[int]] = []
+        assigned: set = set()
+
+        for i in range(len(notes)):
+            if i in assigned:
+                continue
+            cluster = [i]
+            assigned.add(i)
+            for j in range(i + 1, len(notes)):
+                if j in assigned:
+                    continue
+                if _cosine(vectors[i], vectors[j]) >= self.similarity_threshold:
+                    cluster.append(j)
+                    assigned.add(j)
+            clusters.append(cluster)
+
+        return [[notes[i] for i in cluster] for cluster in clusters]
+
+    async def _merge_cluster(self, texts: List[str]) -> str:
+        """Ask the LLM for one sharper lesson; empty string on any failure."""
+        if self.llm is None:
+            return ""
+        system = (
+            "You consolidate an autonomous agent's learned lessons. Merge the "
+            "given near-duplicate lessons into ONE lesson that keeps every "
+            "concrete, actionable detail and drops repetition. Return a single "
+            "sentence of at most 45 words. No preamble."
+        )
+        user_message = "Lessons to merge:\n" + "\n".join(f"- {t}" for t in texts)
+        try:
+            merged = await self.llm.chat(
+                system=system,
+                messages=[{"role": "user", "content": user_message}],
+                temperature=0.3,
+                max_tokens=120,
+            )
+            merged = (merged or "").strip().strip('"')
+            # A merge that lost everything or ballooned is not a merge.
+            if not merged or len(merged) > 500:
+                return ""
+            return merged
+        except Exception as exc:
+            logger.error(f"Lesson merge failed, using fallback: {exc}")
+            return ""
+
+
+__all__ = ["ConsolidationService"]

--- a/tests/test_consolidation.py
+++ b/tests/test_consolidation.py
@@ -1,0 +1,96 @@
+"""Tests for dream consolidation: near-duplicate lessons merge into one."""
+
+from unittest.mock import AsyncMock
+
+from db.models import Note
+from db.session import get_db_session, init_db
+from services.consolidation import ConsolidationService
+from services.ledger import DecisionLedger
+
+
+def _ledger(tmp_path):
+    return DecisionLedger(path=str(tmp_path / "ledger.jsonl"))
+
+
+async def test_near_duplicates_merge_distinct_notes_survive(tmp_path):
+    init_db()
+    llm = AsyncMock()
+    llm.chat = AsyncMock(return_value="Post energy proposals at 9am ET for peak engagement.")
+    service = ConsolidationService(llm, ledger=_ledger(tmp_path))
+
+    with get_db_session() as session:
+        session.add(Note(text="post energy proposals earlier in the morning for engagement"))
+        session.add(Note(text="energy proposals posted in the morning get more engagement"))
+        session.add(Note(text="reply threads about governance need concrete citations"))
+        session.commit()
+
+        result = await service.consolidate(session)
+        remaining = session.query(Note).all()
+
+    assert result["clusters_merged"] == 1
+    assert result["notes_removed"] == 1
+    texts = {n.text for n in remaining}
+    assert "Post energy proposals at 9am ET for peak engagement." in texts
+    assert "reply threads about governance need concrete citations" in texts
+    assert len(remaining) == 2
+
+
+async def test_llm_failure_falls_back_to_newest_note(tmp_path):
+    init_db()
+    llm = AsyncMock()
+    llm.chat = AsyncMock(side_effect=RuntimeError("budget exhausted"))
+    service = ConsolidationService(llm, ledger=_ledger(tmp_path))
+
+    with get_db_session() as session:
+        session.add(Note(text="post energy proposals in the morning for engagement"))
+        session.add(Note(text="morning energy proposals earn much higher engagement"))
+        session.commit()
+
+        result = await service.consolidate(session)
+        remaining = session.query(Note).all()
+
+    assert result["clusters_merged"] == 1
+    assert len(remaining) == 1
+    # Fallback keeps the newest note's text verbatim - sleep never corrupts.
+    assert remaining[0].text == "morning energy proposals earn much higher engagement"
+
+
+async def test_consolidation_is_ledgered_and_idempotent(tmp_path):
+    init_db()
+    ledger = _ledger(tmp_path)
+    llm = AsyncMock()
+    llm.chat = AsyncMock(return_value="Morning energy proposals earn the most engagement.")
+    service = ConsolidationService(llm, ledger=ledger)
+
+    with get_db_session() as session:
+        session.add(Note(text="post energy proposals in the morning for engagement"))
+        session.add(Note(text="morning energy proposals earn much higher engagement"))
+        session.commit()
+
+        await service.consolidate(session)
+        events = ledger.replay("memory_consolidated")
+        assert len(events) == 1
+        assert events[0]["payload"]["cluster_size"] == 2
+
+        # Second pass: nothing similar remains, nothing merges.
+        second = await service.consolidate(session)
+        assert second == {"clusters_merged": 0, "notes_removed": 0}
+    ok, _ = ledger.verify_chain()
+    assert ok is True
+
+
+async def test_unrelated_notes_never_merge(tmp_path):
+    init_db()
+    llm = AsyncMock()
+    service = ConsolidationService(llm, ledger=_ledger(tmp_path))
+
+    with get_db_session() as session:
+        session.add(Note(text="citations from reuters build authority"))
+        session.add(Note(text="quadratic funding pilots convert on weekdays"))
+        session.add(Note(text="threads outperform single posts at intensity two"))
+        session.commit()
+
+        result = await service.consolidate(session)
+        assert result == {"clusters_merged": 0, "notes_removed": 0}
+        assert session.query(Note).count() == 3
+    llm.chat.assert_not_called()


### PR DESCRIPTION
## Summary

Promotes the last governance-safe Phase 7 sketch — dream consolidation — from design to code:

- `services/consolidation.py`: clusters near-duplicate improvement notes using the same hashed bag-of-words embedding as the semantic index (greedy cosine clustering, threshold 0.6), and merges each cluster into one sharper lesson via the LLM.
- **Sleep can never corrupt memory**: on any LLM failure or degenerate output, the newest note of the cluster survives verbatim (deterministic fallback); distinct lessons are never touched; every compression is ledgered as `memory_consolidated`.
- Runs as a daily `dream_consolidation` job at hour 5 (between nightly reflection at 4 and discovery at 6), heartbeat-supervised like every other job.
- Docs updated (`docs/SAFETY_AND_ROLLOUT.md` event list, `replit.md` capabilities).

The remaining Phase 7 items (world model, internal simulator, agent-to-agent protocol) stay as design sketches by deliberate choice — each carries a governance decision that belongs to the owner, with agent-to-agent flagged for a permanent human checkpoint.

## Testing
- `python -m pytest` — **154 passed** (4 new: merge of near-duplicates with distinct notes untouched, LLM-failure fallback keeps newest note verbatim, ledger event + idempotence + chain verification, unrelated notes never merge and never invoke the LLM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnM7HbkV5ouKu3WST9v7fW

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnM7HbkV5ouKu3WST9v7fW)_