### PR TITLE
Add Approvals page with admin auth, world model, and reception simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ self_model_card.md.backup.*
 data/decision_ledger.jsonl
 data/semantic_index.jsonl
 data/agent_store.jsonl
+data/world_model.jsonl

--- a/app.py
+++ b/app.py
@@ -10,7 +10,8 @@ import os
 import sys
 import traceback
 import uuid
-from datetime import datetime, UTC
+import secrets
+from datetime import datetime, timedelta, UTC
 from typing import Dict, List, Optional, Any
 
 import uvicorn
@@ -126,6 +127,9 @@ class ConversionRequest(BaseModel):
 
 class DecisionRequest(BaseModel):
     approve: bool
+
+class TokenRequest(BaseModel):
+    admin_token: str
 
 # WebSocket endpoint for real-time updates
 @app.websocket("/ws")
@@ -268,6 +272,38 @@ async def set_crisis(request: CrisisRequest):
         "crisis_state": "PAUSED" if runner.crisis_service.is_paused() else "NORMAL",
         "crisis_reason": runner.crisis_service.reason,
     }
+
+@app.post("/api/auth/token")
+async def issue_admin_token(request: TokenRequest):
+    """Exchange the ADMIN_TOKEN for a short-lived admin JWT.
+
+    This is what lets the dashboard perform admin actions (approvals,
+    breaker reset, persona updates) without shipping the raw admin token
+    on every request.
+    """
+    import jwt as pyjwt
+
+    if not secrets.compare_digest(request.admin_token, config.ADMIN_TOKEN):
+        logger.warning("Admin token exchange failed: invalid token")
+        raise HTTPException(status_code=401, detail="Invalid admin token")
+
+    now = datetime.now(UTC)
+    expires_hours = 12
+    claims: Dict[str, Any] = {
+        "sub": "admin",
+        "roles": ["admin"],
+        "iat": now,
+        "exp": now + timedelta(hours=expires_hours),
+    }
+    if config.JWT_ISSUER:
+        claims["iss"] = config.JWT_ISSUER
+    if config.JWT_AUDIENCE:
+        claims["aud"] = config.JWT_AUDIENCE
+
+    token = pyjwt.encode(claims, config.JWT_SECRET, algorithm="HS256")
+    get_ledger().record("admin_token_issued", {"expires_hours": expires_hours})
+    return {"token": token, "expires_in": expires_hours * 3600}
+
 
 async def _arming_preflight() -> Dict[str, Any]:
     """Checks that must pass before live posting can be armed.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from "@/components/ui/theme-provider";
 import Dashboard from "@/pages/dashboard";
 import PersonaEditor from "@/pages/persona-editor";
 import Mind from "@/pages/mind";
+import Approvals from "@/pages/approvals";
 import Analytics from "@/pages/analytics";
 import Configuration from "@/pages/configuration";
 import ActivityLog from "@/pages/activity-log";
@@ -34,6 +35,7 @@ function Router() {
             <Route path="/logs" component={ActivityLog} />
             <Route path="/health" component={Health} />
             <Route path="/mind" component={Mind} />
+            <Route path="/approvals" component={Approvals} />
             <Route component={NotFound} />
           </Switch>
         </main>

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -1,20 +1,22 @@
 import { Link, useLocation } from "wouter";
 import { cn } from "@/lib/utils";
-import { 
-  LayoutDashboard, 
-  Brain, 
-  BarChart3, 
-  Settings, 
-  FileText, 
+import {
+  LayoutDashboard,
+  Brain,
+  BarChart3,
+  Settings,
+  FileText,
   Heart,
   Bot,
-  Sparkles
+  Sparkles,
+  CheckSquare
 } from "lucide-react";
 
 const navigation = [
   { name: "Overview", href: "/", icon: LayoutDashboard },
   { name: "Persona Editor", href: "/persona", icon: Brain },
   { name: "The Mind", href: "/mind", icon: Sparkles },
+  { name: "Approvals", href: "/approvals", icon: CheckSquare },
   { name: "Analytics", href: "/analytics", icon: BarChart3 },
   { name: "Configuration", href: "/config", icon: Settings },
   { name: "Activity Log", href: "/logs", icon: FileText },

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -7,6 +7,25 @@ async function throwIfResNotOk(res: Response) {
   }
 }
 
+const ADMIN_JWT_KEY = "daleobanks-admin-jwt";
+
+export function getAdminJwt(): string | null {
+  return localStorage.getItem(ADMIN_JWT_KEY);
+}
+
+export function setAdminJwt(token: string | null): void {
+  if (token) {
+    localStorage.setItem(ADMIN_JWT_KEY, token);
+  } else {
+    localStorage.removeItem(ADMIN_JWT_KEY);
+  }
+}
+
+function authHeaders(): Record<string, string> {
+  const token = getAdminJwt();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 export async function apiRequest(
   method: string,
   url: string,
@@ -14,7 +33,10 @@ export async function apiRequest(
 ): Promise<Response> {
   const res = await fetch(url, {
     method,
-    headers: data ? { "Content-Type": "application/json" } : {},
+    headers: {
+      ...(data ? { "Content-Type": "application/json" } : {}),
+      ...authHeaders(),
+    },
     body: data ? JSON.stringify(data) : undefined,
     credentials: "include",
   });

--- a/client/src/pages/approvals.tsx
+++ b/client/src/pages/approvals.tsx
@@ -1,0 +1,271 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "@/lib/api";
+import { getAdminJwt, setAdminJwt } from "@/lib/queryClient";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+import { Check, X, KeyRound, LogOut, Compass, Target } from "lucide-react";
+
+interface DiscoveryProposal {
+  id: string;
+  kind: string;
+  value: string;
+  evidence: Record<string, unknown>;
+  status: string;
+  created_at: string;
+}
+
+interface GoalProposal {
+  id: string;
+  proposal: Record<string, unknown>;
+  rationale: string;
+  status: string;
+  created_at: string;
+}
+
+function AdminUnlock({ onUnlocked }: { onUnlocked: () => void }) {
+  const { toast } = useToast();
+  const [adminToken, setAdminToken] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const unlock = async () => {
+    setBusy(true);
+    try {
+      const response = await api.post("/api/auth/token", { admin_token: adminToken });
+      setAdminJwt(response.token);
+      setAdminToken("");
+      toast({ title: "Unlocked", description: "Admin session active for 12 hours." });
+      onUnlocked();
+    } catch {
+      toast({
+        title: "Unlock failed",
+        description: "That admin token was not accepted.",
+        variant: "destructive",
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card className="max-w-md">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <KeyRound className="h-4 w-4" /> Admin unlock
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Approvals change what the agent is allowed to become. Paste the
+          ADMIN_TOKEN (from your secrets) to mint a 12-hour admin session.
+        </p>
+        <Label htmlFor="admin-token">Admin token</Label>
+        <Input
+          id="admin-token"
+          type="password"
+          value={adminToken}
+          onChange={(e) => setAdminToken(e.target.value)}
+          placeholder="ADMIN_TOKEN"
+        />
+        <Button onClick={unlock} disabled={busy || !adminToken}>
+          Unlock
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function Approvals() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [unlocked, setUnlocked] = useState(() => Boolean(getAdminJwt()));
+
+  const { data: discoveries } = useQuery<{ count: number; proposals: DiscoveryProposal[] }>({
+    queryKey: ["/api/discoveries"],
+    refetchInterval: 30000,
+  });
+
+  const { data: goals } = useQuery<{ count: number; proposals: GoalProposal[] }>({
+    queryKey: ["/api/goals/proposals"],
+    refetchInterval: 30000,
+  });
+
+  const handleAuthFailure = () => {
+    setAdminJwt(null);
+    setUnlocked(false);
+    toast({
+      title: "Session expired",
+      description: "Unlock again with the admin token.",
+      variant: "destructive",
+    });
+  };
+
+  const decideDiscovery = useMutation({
+    mutationFn: ({ id, approve }: { id: string; approve: boolean }) =>
+      api.post(`/api/discoveries/${id}/decision`, { approve }),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/discoveries"] });
+      toast({
+        title: variables.approve ? "Approved" : "Rejected",
+        description: variables.approve
+          ? "The agent's perception will widen on its next scan."
+          : "The proposal was declined.",
+      });
+    },
+    onError: handleAuthFailure,
+  });
+
+  const decideGoal = useMutation({
+    mutationFn: ({ id, approve }: { id: string; approve: boolean }) =>
+      api.post(`/api/goals/proposals/${id}/decision`, { approve }),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/goals/proposals"] });
+      toast({
+        title: variables.approve ? "Approved" : "Rejected",
+        description: variables.approve
+          ? "The new OKR takes effect at the next planning cycle."
+          : "The proposal was declined.",
+      });
+    },
+    onError: handleAuthFailure,
+  });
+
+  const pendingDiscoveries = discoveries?.proposals ?? [];
+  const pendingGoals = goals?.proposals ?? [];
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">Approvals</h1>
+          <p className="text-muted-foreground mt-1">
+            The agent proposes; you decide. Nothing here takes effect without you.
+          </p>
+        </div>
+        {unlocked && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setAdminJwt(null);
+              setUnlocked(false);
+            }}
+          >
+            <LogOut className="mr-2 h-4 w-4" /> Lock
+          </Button>
+        )}
+      </div>
+
+      {!unlocked && <AdminUnlock onUnlocked={() => setUnlocked(true)} />}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Compass className="h-4 w-4" />
+            Discovery proposals
+            <Badge variant="secondary">{pendingDiscoveries.length}</Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {pendingDiscoveries.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No pending proposals. The daily discovery job files new voices and
+              keywords here when real engagement earns them.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {pendingDiscoveries.map((p) => (
+                <div
+                  key={p.id}
+                  className="flex items-center justify-between p-3 border border-border rounded-lg"
+                >
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <Badge>{p.kind}</Badge>
+                      <span className="font-medium">{p.value}</span>
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {JSON.stringify(p.evidence)}
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      disabled={!unlocked || decideDiscovery.isPending}
+                      onClick={() => decideDiscovery.mutate({ id: p.id, approve: true })}
+                    >
+                      <Check className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={!unlocked || decideDiscovery.isPending}
+                      onClick={() => decideDiscovery.mutate({ id: p.id, approve: false })}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Target className="h-4 w-4" />
+            Goal proposals
+            <Badge variant="secondary">{pendingGoals.length}</Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {pendingGoals.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No pending proposals. The planner files OKR adjustments here when
+              performance suggests raising or reducing ambition.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {pendingGoals.map((p) => (
+                <div
+                  key={p.id}
+                  className="flex items-center justify-between p-3 border border-border rounded-lg"
+                >
+                  <div className="pr-4">
+                    <p className="text-sm font-medium">{p.rationale}</p>
+                    <pre className="text-xs text-muted-foreground mt-1 whitespace-pre-wrap">
+                      {JSON.stringify(p.proposal, null, 2)}
+                    </pre>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      disabled={!unlocked || decideGoal.isPending}
+                      onClick={() => decideGoal.mutate({ id: p.id, approve: true })}
+                    >
+                      <Check className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={!unlocked || decideGoal.isPending}
+                      onClick={() => decideGoal.mutate({ id: p.id, approve: false })}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/conftest.py
+++ b/conftest.py
@@ -31,6 +31,12 @@ if "SEMANTIC_INDEX_PATH" not in os.environ:
         tempfile.mkdtemp(prefix="daleobanks-semindex-"), "semantic_index.jsonl"
     )
 
+# Same for the world model (see services/world_model.py).
+if "WORLD_MODEL_PATH" not in os.environ:
+    os.environ["WORLD_MODEL_PATH"] = os.path.join(
+        tempfile.mkdtemp(prefix="daleobanks-worldmodel-"), "world_model.jsonl"
+    )
+
 # Run the object store purely in memory so tests stay isolated (init_db()
 # gives every test a clean slate). Persistence has dedicated tests that
 # opt back in with a temp snapshot path.

--- a/docs/SAFETY_AND_ROLLOUT.md
+++ b/docs/SAFETY_AND_ROLLOUT.md
@@ -30,8 +30,9 @@ Events currently chained: `startup`, `publish_attempt` / `publish_gated` /
 (arming ceremony), `dm_received` (metadata only — never private text),
 `revenue_event` / `link_click`, `discovery_proposal` /
 `discovery_decision`, `okr_proposal` / `okr_decision`, `memory_consolidated` (dream
-consolidation), and `constitution_hash` / `constitution_tampered` /
-`constitution_missing`.
+consolidation), `reception_prediction` (internal simulator),
+`admin_token_issued` (dashboard admin sessions), and
+`constitution_hash` / `constitution_tampered` / `constitution_missing`.
 
 The app verifies the chain at startup (`app.py`); a broken chain disarms
 live mode before anything can act.

--- a/replit.md
+++ b/replit.md
@@ -147,6 +147,9 @@ The architecture prioritizes modularity, safety, and autonomous operation while 
 - **Gated discovery**: daily job proposes new voices/keywords from real engagement; `POST /api/discoveries/{id}/decision` approves; only approvals widen perception.
 - **Constitution**: `constitution.md` hashed into the ledger at startup, re-verified nightly (drift disarms). Planner files OKR changes as `GoalProposal`s, applied only after `POST /api/goals/proposals/{id}/decision` approval.
 - **Dream consolidation**: a daily idle-hours job clusters near-duplicate lessons (same embedding as the semantic index) and merges each cluster into one sharper lesson via the LLM, with a deterministic keep-newest fallback; every compression is ledgered as `memory_consolidated`.
+- **Approvals page** (`/approvals`): lists pending discovery and goal proposals with approve/reject; `POST /api/auth/token` exchanges the ADMIN_TOKEN for a 12-hour admin JWT the client attaches to all requests.
+- **World model** (`data/world_model.jsonl`): every observed mention, timeline post, and trend is durably embedded; generation context includes topic-relevant observations.
+- **Internal simulator**: advisory reception prediction (topic/hour history with shrinkage) ledgered as `reception_prediction` before each proposal publish.
 
 ### Testing
 - `python -m pytest` (150 tests) and `npm run check` must pass; `tests/stubs/` provides offline fallbacks for third-party packages.

--- a/runner.py
+++ b/runner.py
@@ -38,6 +38,7 @@ from services.critic import Critic
 from services.ethics_guard import EthicsGuard
 from services.heartbeat import Heartbeat
 from services.ledger import get_kill_switch, get_ledger
+from services.simulator import ReceptionPredictor
 from services.thought_dsl import ThoughtPlan, ThoughtInterpreter
 from services.world_model import get_world_model
 
@@ -74,6 +75,7 @@ thought_interpreter = ThoughtInterpreter(
 heartbeat = Heartbeat(get_kill_switch(), get_ledger())
 constitution_guard = ConstitutionGuard(ledger=get_ledger(), kill_switch=get_kill_switch())
 consolidation_service = ConsolidationService(llm_adapter, ledger=get_ledger())
+reception_predictor = ReceptionPredictor()
 
 # Track pagination cursors for perception ingest to avoid refetching.
 _perception_state: Dict[str, Any] = {}
@@ -286,6 +288,21 @@ async def post_proposal_job():
                 "Proposal blocked by thought gate: %s", verdict.get("reasons")
             )
             return
+
+        # Internal simulator (advisory): predict reception from history and
+        # ledger it next to the publish so predicted-vs-actual is auditable.
+        try:
+            with get_db_session() as session:
+                prediction = reception_predictor.predict(
+                    session, topic=topic, hour=action.get("hour_bin"),
+                )
+            get_ledger().record("reception_prediction", {
+                "topic": topic,
+                "hour": action.get("hour_bin"),
+                **prediction,
+            })
+        except Exception as exc:
+            logger.error(f"Reception prediction failed: {exc}")
 
         publish_result = await multiplexer.publish(
             result["content"],

--- a/runner.py
+++ b/runner.py
@@ -39,6 +39,7 @@ from services.ethics_guard import EthicsGuard
 from services.heartbeat import Heartbeat
 from services.ledger import get_kill_switch, get_ledger
 from services.thought_dsl import ThoughtPlan, ThoughtInterpreter
+from services.world_model import get_world_model
 
 logger = get_logger(__name__)
 
@@ -995,6 +996,14 @@ async def perception_job():
             )
             _perception_state = perception_service.last_state
         payload = perception_service.last_payload
+
+        # Fold what was seen into the durable world model so knowledge of
+        # the environment outlives the scan.
+        try:
+            if isinstance(payload, dict):
+                get_world_model().observe_perception(payload)
+        except Exception as exc:
+            logger.error(f"World model update failed: {exc}")
         counts = perception_service.last_counts
         mentions = payload.get("x", {}).get("mentions", []) if isinstance(payload, dict) else []
         mention_velocity = counts.get("x_mentions") if isinstance(counts, dict) else None

--- a/services/generator.py
+++ b/services/generator.py
@@ -319,6 +319,12 @@ class Generator:
                 f"- {lesson}" for lesson in associative
             ) + "\n"
 
+        observed = context.get("world_context") or []
+        if observed:
+            lessons_block += "\nRecently observed in the environment:\n" + "\n".join(
+                f"- {item}" for item in observed
+            ) + "\n"
+
         prompt = f"""Generate a proposal tweet about {topic}.
 
 Template to follow: {template}

--- a/services/memory.py
+++ b/services/memory.py
@@ -251,4 +251,12 @@ class MemoryService:
         }
         if topic:
             context["associative_lessons"] = self.search_similar_lessons(topic, k=3)
+            try:
+                from services.world_model import get_world_model
+                context["world_context"] = [
+                    r["text"] for r in get_world_model().recall(topic, k=3)
+                ]
+            except Exception as exc:
+                logger.error(f"World model recall failed: {exc}")
+                context["world_context"] = []
         return context

--- a/services/simulator.py
+++ b/services/simulator.py
@@ -1,0 +1,86 @@
+"""Internal simulator: predict audience reception before posting.
+
+Before an outbound proposal is published, the predictor estimates its
+J-score from the agent's own history - shrinkage-weighted means by topic
+and posting hour, pulled toward the global mean when evidence is thin, so
+sparse data cannot produce confident nonsense.
+
+The prediction is advisory in this version: it is recorded in the decision
+ledger next to the publish attempt (so predicted vs. actual reception can
+be audited and a learned predictor can replace the heuristic later), but it
+never blocks a post. Blocking on a heuristic's guess would let thin data
+silence the agent; the gates that can block remain the ethics/critic ones.
+"""
+
+from __future__ import annotations
+
+from statistics import mean
+from typing import Any, Dict, List, Optional
+
+from db.models import Tweet
+from services.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class ReceptionPredictor:
+    """Heuristic J-score prediction from topic and hour history."""
+
+    def __init__(self, min_samples: int = 5, shrinkage: float = 3.0) -> None:
+        self.min_samples = min_samples
+        self.shrinkage = shrinkage
+
+    def predict(
+        self,
+        session: Any,
+        *,
+        topic: Optional[str],
+        hour: Optional[int],
+    ) -> Dict[str, Any]:
+        """Predict reception. predicted_j is None while history is thin."""
+        scored: List[Tweet] = (
+            session.query(Tweet)
+            .filter(lambda t: t.j_score is not None)
+            .all()
+        )
+        if len(scored) < self.min_samples:
+            return {
+                "predicted_j": None,
+                "confidence": 0.0,
+                "basis": "insufficient_history",
+                "samples": len(scored),
+            }
+
+        global_mean = mean(t.j_score for t in scored)
+
+        topic_scores = [t.j_score for t in scored if topic and t.topic == topic]
+        hour_scores = [t.j_score for t in scored if hour is not None and t.hour_bin == hour]
+
+        topic_estimate = self._shrunk_mean(topic_scores, global_mean)
+        hour_estimate = self._shrunk_mean(hour_scores, global_mean)
+        predicted = 0.6 * topic_estimate + 0.4 * hour_estimate
+
+        evidence = len(topic_scores) + len(hour_scores)
+        confidence = round(min(evidence / 20.0, 1.0), 3)
+
+        return {
+            "predicted_j": round(predicted, 3),
+            "confidence": confidence,
+            "basis": "topic_hour_history",
+            "samples": {
+                "total_scored": len(scored),
+                "topic": len(topic_scores),
+                "hour": len(hour_scores),
+            },
+            "global_mean": round(global_mean, 3),
+        }
+
+    def _shrunk_mean(self, scores: List[float], global_mean: float) -> float:
+        """Sample mean pulled toward the global mean when evidence is thin."""
+        if not scores:
+            return global_mean
+        weight = len(scores) / (len(scores) + self.shrinkage)
+        return weight * mean(scores) + (1 - weight) * global_mean
+
+
+__all__ = ["ReceptionPredictor"]

--- a/services/world_model.py
+++ b/services/world_model.py
@@ -1,0 +1,126 @@
+"""Self-authored world model: durable, associative memory of the environment.
+
+Perception scans are ephemeral - each cycle's mentions, timeline posts, and
+trends are processed and dropped. The world model keeps them: every observed
+entity and event is embedded into its own semantic index (separate file from
+the lesson index), so the planner and generator can ask "what do I know
+about X" and get answers grounded in things the agent actually saw, with
+timestamps and sources.
+
+Observations are just data. Nothing in the world model can direct action;
+it only informs generation context, per the constitution's inbound-content
+invariant.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, UTC
+from typing import Any, Dict, List, Optional
+
+from services.logging_utils import get_logger
+from services.semantic_index import SemanticIndex
+
+logger = get_logger(__name__)
+
+
+def default_world_model_path() -> str:
+    return os.getenv("WORLD_MODEL_PATH", os.path.join("data", "world_model.jsonl"))
+
+
+class WorldModel:
+    """Embedded, durable records of observed entities and events."""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self.index = SemanticIndex(path=path or default_world_model_path())
+
+    def observe(
+        self,
+        *,
+        kind: str,
+        summary: str,
+        entity: Optional[str] = None,
+        source: str = "x",
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Record one observation. Returns the record id (None on failure)."""
+        summary = (summary or "").strip()
+        if not summary:
+            return None
+        try:
+            record_meta = {
+                "kind": kind,
+                "entity": entity,
+                "source": source,
+                "observed_at": datetime.now(UTC).isoformat(),
+                **(meta or {}),
+            }
+            text = f"{entity}: {summary}" if entity else summary
+            return self.index.add(text, meta=record_meta)
+        except Exception as exc:
+            logger.error(f"World model observation failed: {exc}")
+            return None
+
+    def observe_perception(self, payload: Dict[str, Any]) -> int:
+        """Fold one perception payload (mentions/timeline/trends) in."""
+        observed = 0
+        x_payload = payload.get("x") or {}
+
+        for mention in x_payload.get("mentions", []) or []:
+            if not isinstance(mention, dict):
+                continue
+            if self.observe(
+                kind="mention",
+                entity=mention.get("username"),
+                summary=str(mention.get("text", ""))[:280],
+                meta={"post_id": mention.get("id")},
+            ):
+                observed += 1
+
+        for post in x_payload.get("home_timeline", []) or []:
+            if not isinstance(post, dict):
+                continue
+            if self.observe(
+                kind="timeline_post",
+                entity=post.get("username") or post.get("author_id"),
+                summary=str(post.get("text", ""))[:280],
+                meta={"post_id": post.get("id")},
+            ):
+                observed += 1
+
+        for trend in x_payload.get("trending_topics", []) or []:
+            summary = trend.get("name") if isinstance(trend, dict) else str(trend)
+            if self.observe(kind="trend", summary=str(summary)[:120]):
+                observed += 1
+
+        return observed
+
+    def recall(self, query: str, k: int = 5) -> List[Dict[str, Any]]:
+        """What does the agent know about this, from direct observation?"""
+        try:
+            return self.index.search(query, k=k)
+        except Exception as exc:
+            logger.error(f"World model recall failed: {exc}")
+            return []
+
+    def __len__(self) -> int:
+        return len(self.index)
+
+
+_SHARED_WORLD_MODEL: Optional[WorldModel] = None
+
+
+def get_world_model() -> WorldModel:
+    global _SHARED_WORLD_MODEL
+    if _SHARED_WORLD_MODEL is None:
+        _SHARED_WORLD_MODEL = WorldModel()
+    return _SHARED_WORLD_MODEL
+
+
+def set_world_model(model: Optional[WorldModel]) -> None:
+    """Swap the shared world model (used by tests)."""
+    global _SHARED_WORLD_MODEL
+    _SHARED_WORLD_MODEL = model
+
+
+__all__ = ["WorldModel", "get_world_model", "set_world_model", "default_world_model_path"]

--- a/tests/test_auth_token.py
+++ b/tests/test_auth_token.py
@@ -1,0 +1,49 @@
+"""Tests for the admin token exchange (ADMIN_TOKEN -> short-lived JWT)."""
+
+import jwt as pyjwt
+import pytest
+from fastapi import HTTPException
+
+from config import get_config
+from services.ledger import DecisionLedger, set_shared_instances, reset_shared_instances
+
+
+async def test_valid_admin_token_mints_admin_jwt(tmp_path):
+    ledger = DecisionLedger(path=str(tmp_path / "ledger.jsonl"))
+    set_shared_instances(ledger=ledger)
+    try:
+        import app as app_module
+
+        config = get_config()
+        response = await app_module.issue_admin_token(
+            app_module.TokenRequest(admin_token=config.ADMIN_TOKEN)
+        )
+
+        claims = pyjwt.decode(
+            response["token"],
+            config.JWT_SECRET,
+            algorithms=["HS256"],
+            options={"verify_aud": False},
+        )
+        assert claims["sub"] == "admin"
+        assert claims["roles"] == ["admin"]
+        assert response["expires_in"] == 12 * 3600
+        assert ledger.replay("admin_token_issued")
+    finally:
+        reset_shared_instances()
+
+
+async def test_wrong_admin_token_is_rejected(tmp_path):
+    ledger = DecisionLedger(path=str(tmp_path / "ledger.jsonl"))
+    set_shared_instances(ledger=ledger)
+    try:
+        import app as app_module
+
+        with pytest.raises(HTTPException) as exc_info:
+            await app_module.issue_admin_token(
+                app_module.TokenRequest(admin_token="not-the-token")
+            )
+        assert exc_info.value.status_code == 401
+        assert ledger.replay("admin_token_issued") == []
+    finally:
+        reset_shared_instances()

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,75 @@
+"""Tests for the reception predictor (internal simulator)."""
+
+from db.models import Tweet
+from db.session import get_db_session, init_db
+from services.simulator import ReceptionPredictor
+
+
+def _seed(session, topic, hour, scores):
+    for i, score in enumerate(scores):
+        session.add(Tweet(
+            id=f"{topic}-{hour}-{i}", text="x", kind="proposal",
+            topic=topic, hour_bin=hour, j_score=score,
+        ))
+    session.commit()
+
+
+def test_thin_history_predicts_nothing():
+    init_db()
+    predictor = ReceptionPredictor(min_samples=5)
+
+    with get_db_session() as session:
+        _seed(session, "energy", 9, [0.8, 0.7])
+        result = predictor.predict(session, topic="energy", hour=9)
+
+    assert result["predicted_j"] is None
+    assert result["basis"] == "insufficient_history"
+    assert result["confidence"] == 0.0
+
+
+def test_strong_topic_predicts_higher_than_weak_topic():
+    init_db()
+    predictor = ReceptionPredictor(min_samples=5)
+
+    with get_db_session() as session:
+        _seed(session, "energy", 9, [0.9, 0.85, 0.8, 0.9])
+        _seed(session, "gossip", 21, [0.1, 0.15, 0.1, 0.05])
+
+        strong = predictor.predict(session, topic="energy", hour=9)
+        weak = predictor.predict(session, topic="gossip", hour=21)
+
+    assert strong["predicted_j"] is not None
+    assert strong["predicted_j"] > weak["predicted_j"]
+    assert 0 < strong["confidence"] <= 1
+
+
+def test_unknown_topic_shrinks_to_global_mean():
+    init_db()
+    predictor = ReceptionPredictor(min_samples=5)
+
+    with get_db_session() as session:
+        _seed(session, "energy", 9, [0.6, 0.6, 0.6, 0.6, 0.6])
+        result = predictor.predict(session, topic="never-seen", hour=3)
+
+    # No topic or hour evidence: the prediction is exactly the global mean.
+    assert result["predicted_j"] == result["global_mean"] == 0.6
+    assert result["samples"]["topic"] == 0
+    assert result["samples"]["hour"] == 0
+
+
+def test_shrinkage_tempers_small_samples():
+    init_db()
+    predictor = ReceptionPredictor(min_samples=5, shrinkage=3.0)
+
+    with get_db_session() as session:
+        # Global mean pulled low by many mediocre posts...
+        _seed(session, "misc", 12, [0.3] * 10)
+        # ...one lucky high-scorer on a new topic must not dominate.
+        _seed(session, "newtopic", 9, [1.0])
+
+        result = predictor.predict(session, topic="newtopic", hour=9)
+
+    global_mean = result["global_mean"]
+    # Prediction sits between the global mean and the single sample,
+    # much closer to the mean than to 1.0.
+    assert global_mean < result["predicted_j"] < 0.6

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -1,0 +1,75 @@
+"""Tests for the world model: durable memory of the observed environment."""
+
+from services.world_model import WorldModel
+
+
+def _model(tmp_path):
+    return WorldModel(path=str(tmp_path / "world.jsonl"))
+
+
+def test_observations_are_recallable(tmp_path):
+    model = _model(tmp_path)
+    model.observe(kind="mention", entity="gridwonk",
+                  summary="interconnection queues are the real bottleneck")
+    model.observe(kind="trend", summary="quadratic funding")
+
+    hits = model.recall("interconnection bottleneck", k=1)
+    assert len(hits) == 1
+    assert hits[0]["meta"]["kind"] == "mention"
+    assert hits[0]["meta"]["entity"] == "gridwonk"
+    assert "observed_at" in hits[0]["meta"]
+
+
+def test_perception_payload_is_folded_in(tmp_path):
+    model = _model(tmp_path)
+    payload = {
+        "x": {
+            "mentions": [
+                {"id": "m1", "username": "ally", "text": "love the grid proposal"},
+            ],
+            "home_timeline": [
+                {"id": "t1", "username": "wonk", "text": "transmission reform news"},
+            ],
+            "trending_topics": [{"name": "energy markets"}, "governance"],
+        }
+    }
+
+    observed = model.observe_perception(payload)
+
+    assert observed == 4
+    assert len(model) == 4
+    trends = [r for r in model.recall("energy markets", k=4) if r["meta"]["kind"] == "trend"]
+    assert trends
+
+
+def test_world_model_survives_restart(tmp_path):
+    path = str(tmp_path / "world.jsonl")
+    WorldModel(path=path).observe(kind="mention", entity="ally", summary="pilot feedback")
+
+    reloaded = WorldModel(path=path)
+    assert len(reloaded) == 1
+    assert reloaded.recall("pilot feedback", k=1)
+
+
+def test_empty_and_malformed_observations_are_safe(tmp_path):
+    model = _model(tmp_path)
+    assert model.observe(kind="mention", summary="") is None
+    assert model.observe_perception({}) == 0
+    assert model.observe_perception({"x": {"mentions": ["not-a-dict"]}}) == 0
+
+
+def test_generation_context_includes_world_context(tmp_path, monkeypatch):
+    from services import world_model as wm_module
+    from db.session import init_db, get_db_session
+    from services.memory import MemoryService
+
+    isolated = WorldModel(path=str(tmp_path / "world.jsonl"))
+    isolated.observe(kind="trend", summary="grid interconnection reform")
+    monkeypatch.setattr(wm_module, "_SHARED_WORLD_MODEL", isolated)
+
+    init_db()
+    service = MemoryService()
+    with get_db_session() as session:
+        context = service.get_context_for_generation(session, topic="interconnection")
+
+    assert context["world_context"] == ["grid interconnection reform"]


### PR DESCRIPTION
## Summary

The three remaining buildable items, done:

- **Approvals dashboard** (`/approvals`): the human-gate workflow no longer needs curl. `POST /api/auth/token` exchanges the `ADMIN_TOKEN` (constant-time compared) for a 12-hour admin JWT, ledgered as `admin_token_issued`; the client stores it and attaches `Authorization` to every request, which also makes the existing admin-gated endpoints (persona updates, breaker reset) work from the browser. The page lists pending discovery proposals (with evidence) and goal proposals (with rationale), approve/reject per item, locked-until-unlocked, session-expiry re-prompt.
- **Self-authored world model**: `services/world_model.py` durably embeds every observed mention, timeline post, and trend (own semantic index at `data/world_model.jsonl`) with kind/entity/timestamp metadata. `perception_job` folds each scan in; generation context now includes topic-relevant "recently observed in the environment" items. Observations are data only — they inform generation, never direct action.
- **Internal simulator**: `services/simulator.py` predicts a proposal's J-score from topic/hour history with shrinkage toward the global mean (predicts nothing below 5 scored posts). Recorded as `reception_prediction` in the ledger before each publish so predicted-vs-actual is auditable; deliberately advisory — a heuristic's guess never blocks a post.

The agent-to-agent protocol remains unbuilt by design: it's the highest-risk item and needs an explicit owner decision with a permanent human checkpoint.

## Testing
- `python -m pytest` — **165 passed** (11 new)
- `tsc` clean; `vite build` passes
- Production boot verified live: token mint 200 with correct ADMIN_TOKEN, 401 with wrong; `POST /api/breaker/reset` 403 without JWT and 200 with it; frontend and all API routes 200 through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnM7HbkV5ouKu3WST9v7fW

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnM7HbkV5ouKu3WST9v7fW)_