### PR TITLE
Add compounding advantages: self-calibrating forecaster, relationship-aware replies, evidence library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ data/decision_ledger.jsonl
 data/semantic_index.jsonl
 data/agent_store.jsonl
 data/world_model.jsonl
+data/evidence_library.jsonl
 self_model_card.md

--- a/conftest.py
+++ b/conftest.py
@@ -37,6 +37,12 @@ if "WORLD_MODEL_PATH" not in os.environ:
         tempfile.mkdtemp(prefix="daleobanks-worldmodel-"), "world_model.jsonl"
     )
 
+# Same for the evidence library (see services/evidence_library.py).
+if "EVIDENCE_LIBRARY_PATH" not in os.environ:
+    os.environ["EVIDENCE_LIBRARY_PATH"] = os.path.join(
+        tempfile.mkdtemp(prefix="daleobanks-evidence-"), "evidence_library.jsonl"
+    )
+
 # Run the object store purely in memory so tests stay isolated (init_db()
 # gives every test a clean slate). Persistence has dedicated tests that
 # opt back in with a temp snapshot path.

--- a/db/models.py
+++ b/db/models.py
@@ -35,6 +35,7 @@ class Tweet:
     quotes: int = 0
     authority_score: float = 0.0
     j_score: Optional[float] = 0.0
+    predicted_j: Optional[float] = None  # simulator forecast at publish time
 
 
 @dataclass

--- a/docs/SAFETY_AND_ROLLOUT.md
+++ b/docs/SAFETY_AND_ROLLOUT.md
@@ -30,7 +30,7 @@ Events currently chained: `startup`, `publish_attempt` / `publish_gated` /
 (arming ceremony), `dm_received` (metadata only — never private text),
 `revenue_event` / `link_click`, `discovery_proposal` /
 `discovery_decision`, `okr_proposal` / `okr_decision`, `memory_consolidated` (dream
-consolidation), `reception_prediction` (internal simulator),
+consolidation), `reception_prediction` / `prediction_accuracy` (self-calibrating simulator),
 `admin_token_issued` (dashboard admin sessions), and
 `constitution_hash` / `constitution_tampered` / `constitution_missing`.
 

--- a/replit.md
+++ b/replit.md
@@ -154,4 +154,4 @@ The architecture prioritizes modularity, safety, and autonomous operation while 
 - **Relationship-aware replies**: reply prompts include the account's interaction history, sentiment trend, and topics from social memory.
 
 ### Testing
-- `python -m pytest` (150 tests) and `npm run check` must pass; `tests/stubs/` provides offline fallbacks for third-party packages.
+- `python -m pytest` (172 tests) and `npm run check` must pass; `tests/stubs/` provides offline fallbacks for third-party packages.

--- a/replit.md
+++ b/replit.md
@@ -149,7 +149,9 @@ The architecture prioritizes modularity, safety, and autonomous operation while 
 - **Dream consolidation**: a daily idle-hours job clusters near-duplicate lessons (same embedding as the semantic index) and merges each cluster into one sharper lesson via the LLM, with a deterministic keep-newest fallback; every compression is ledgered as `memory_consolidated`.
 - **Approvals page** (`/approvals`): lists pending discovery and goal proposals with approve/reject; `POST /api/auth/token` exchanges the ADMIN_TOKEN for a 12-hour admin JWT the client attaches to all requests.
 - **World model** (`data/world_model.jsonl`): every observed mention, timeline post, and trend is durably embedded; generation context includes topic-relevant observations.
-- **Internal simulator**: advisory reception prediction (topic/hour history with shrinkage) ledgered as `reception_prediction` before each proposal publish.
+- **Internal simulator**: advisory reception prediction (topic/hour history with shrinkage) ledgered as `reception_prediction` before each proposal publish; forecasts are stored on the Tweet (`predicted_j`), audited nightly (`prediction_accuracy`), and self-calibrate against past errors.
+- **Evidence library** (`data/evidence_library.jsonl`): trusted citations from validated content are banked once and recalled by topic into proposal prompts as pre-vetted sources.
+- **Relationship-aware replies**: reply prompts include the account's interaction history, sentiment trend, and topics from social memory.
 
 ### Testing
 - `python -m pytest` (150 tests) and `npm run check` must pass; `tests/stubs/` provides offline fallbacks for third-party packages.

--- a/runner.py
+++ b/runner.py
@@ -291,6 +291,7 @@ async def post_proposal_job():
 
         # Internal simulator (advisory): predict reception from history and
         # ledger it next to the publish so predicted-vs-actual is auditable.
+        prediction: Dict[str, Any] = {}
         try:
             with get_db_session() as session:
                 prediction = reception_predictor.predict(
@@ -326,6 +327,7 @@ async def post_proposal_job():
                     hour_bin=action.get("hour_bin"),
                     cta_variant=action.get("cta_variant"),
                     intensity=action.get("intensity"),
+                    predicted_j=prediction.get("predicted_j"),
                 )
                 session.add(tweet)
                 session.commit()
@@ -412,6 +414,20 @@ async def reply_mentions_job():
                     "author_info": {"username": mention.get("username", "unknown")},
                     "topic": topic
                 }
+
+                # Social memory: replies acknowledge shared history.
+                with get_db_session() as session:
+                    rel = memory_service.get_relationship(
+                        session,
+                        mention.get("author_id") or mention.get("username", ""),
+                    )
+                if rel:
+                    context["relationship"] = {
+                        "handle": rel.handle,
+                        "interactions": rel.interaction_count,
+                        "sentiment": rel.sentiment_score,
+                        "topics": list(rel.topics),
+                    }
 
                 intensity = action.get("intensity", config.MIN_INTENSITY_LEVEL)
                 result = await generator.make_reply(context, intensity)
@@ -1111,6 +1127,16 @@ async def nightly_reflection_job():
         # Values check: a constitution that changed underneath a running
         # process disarms live posting before any further learning.
         constitution_guard.verify()
+
+        # Forecast audit: how well have reception predictions matched
+        # reality? Ledgered so calibration drift is visible over time.
+        try:
+            with get_db_session() as session:
+                accuracy = reception_predictor.prediction_accuracy(session)
+            if accuracy.get("pairs"):
+                get_ledger().record("prediction_accuracy", accuracy)
+        except Exception as exc:
+            logger.error(f"Prediction accuracy audit failed: {exc}")
 
         with get_db_session() as session:
             improvement_note = await reflection_service.generate_reflection_async(session)

--- a/services/evidence_library.py
+++ b/services/evidence_library.py
@@ -1,0 +1,92 @@
+"""Evidence library: verified citations become durable, reusable assets.
+
+Every time a published piece of content passes the citation gate, the
+trusted URLs it cited are recorded here with their topic and context.
+Future generation recalls pre-vetted sources by topic, so the agent walks
+into every proposal already holding receipts instead of hoping the LLM
+invents a citable link — raising both evidence quality and the pass rate
+of the citation gate over time.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from services.logging_utils import get_logger
+from services.semantic_index import SemanticIndex
+
+logger = get_logger(__name__)
+
+
+def default_evidence_path() -> str:
+    return os.getenv("EVIDENCE_LIBRARY_PATH", os.path.join("data", "evidence_library.jsonl"))
+
+
+class EvidenceLibrary:
+    """Durable, topic-recallable store of verified citations."""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self.index = SemanticIndex(path=path or default_evidence_path())
+        self._seen_urls = {
+            record.get("meta", {}).get("url")
+            for record in self.index.records()
+            if record.get("meta", {}).get("url")
+        }
+
+    def record(self, *, url: str, topic: str, context: str = "") -> Optional[str]:
+        """Store a verified citation once. Returns record id or None."""
+        url = (url or "").strip()
+        if not url or url in self._seen_urls:
+            return None
+        try:
+            text = f"{topic}: {context[:160]} [{url}]" if context else f"{topic} [{url}]"
+            record_id = self.index.add(text, meta={
+                "kind": "evidence",
+                "url": url,
+                "topic": topic,
+            })
+            self._seen_urls.add(url)
+            return record_id
+        except Exception as exc:
+            logger.error(f"Failed to record evidence: {exc}")
+            return None
+
+    def recall(self, topic: str, k: int = 3) -> List[Dict[str, Any]]:
+        """Pre-vetted sources relevant to a topic: [{url, text}, ...]."""
+        try:
+            return [
+                {"url": hit["meta"].get("url"), "text": hit["text"]}
+                for hit in self.index.search(topic, k=k)
+                if hit.get("meta", {}).get("url")
+            ]
+        except Exception as exc:
+            logger.error(f"Evidence recall failed: {exc}")
+            return []
+
+    def __len__(self) -> int:
+        return len(self.index)
+
+
+_SHARED_LIBRARY: Optional[EvidenceLibrary] = None
+
+
+def get_evidence_library() -> EvidenceLibrary:
+    global _SHARED_LIBRARY
+    if _SHARED_LIBRARY is None:
+        _SHARED_LIBRARY = EvidenceLibrary()
+    return _SHARED_LIBRARY
+
+
+def set_evidence_library(library: Optional[EvidenceLibrary]) -> None:
+    """Swap the shared library (used by tests)."""
+    global _SHARED_LIBRARY
+    _SHARED_LIBRARY = library
+
+
+__all__ = [
+    "EvidenceLibrary",
+    "get_evidence_library",
+    "set_evidence_library",
+    "default_evidence_path",
+]

--- a/services/generator.py
+++ b/services/generator.py
@@ -60,6 +60,10 @@ class Generator:
         from services.websearch import WebSearchService
         self.websearch = WebSearchService()
 
+        # Library of previously verified citations, recallable by topic
+        from services.evidence_library import get_evidence_library
+        self.evidence_library = get_evidence_library()
+
         # Duplicate detection settings
         self.duplicate_check_days = 30
         self.similarity_threshold = 0.8
@@ -325,6 +329,14 @@ class Generator:
                 f"- {item}" for item in observed
             ) + "\n"
 
+        receipts = self.evidence_library.recall(topic, k=3)
+        if receipts:
+            lessons_block += (
+                "\nVerified sources you may cite (already vetted):\n"
+                + "\n".join(f"- {r['url']}" for r in receipts)
+                + "\n"
+            )
+
         prompt = f"""Generate a proposal tweet about {topic}.
 
 Template to follow: {template}
@@ -354,11 +366,21 @@ Topic focus: {topic}"""
 
         reply_override = self.persona_store.get_reply_style_override()
 
+        relationship = context.get("relationship") or {}
+        relationship_block = ""
+        if relationship:
+            topics = ", ".join(relationship.get("topics", [])) or "unknown"
+            relationship_block = (
+                f"\nHistory with this account: {relationship.get('interactions', 0)} prior "
+                f"interactions, sentiment trend {relationship.get('sentiment', 0.0):+.2f}, "
+                f"topics they care about: {topics}. Be consistent with that history.\n"
+            )
+
         prompt = f"""Generate a reply to this tweet:
 
 Original tweet: "{original_tweet}"
 Author: {author_info.get("username", "unknown")} (followers: {author_info.get("followers", 0)})
-
+{relationship_block}
 Template to follow: {template}
 
 Tone rules:
@@ -650,6 +672,17 @@ Requirements:
                     requirement_text = ", ".join(requirements[:-1]) + f", and {requirements[-1]}"
 
                 return {"error": f"High-intensity content must {requirement_text}."}
+
+        # Content passed every gate: bank its trusted citations so future
+        # generation starts with pre-vetted receipts for this topic.
+        try:
+            for url in self.websearch.extract_urls(content):
+                if self.websearch.is_trusted(url):
+                    self.evidence_library.record(
+                        url=url, topic=topic, context=content[:160]
+                    )
+        except Exception as e:
+            logger.error(f"Evidence banking failed: {e}")
 
         return {
             "content": content,

--- a/services/semantic_index.py
+++ b/services/semantic_index.py
@@ -97,6 +97,11 @@ class SemanticIndex:
             self._vectors.append(vector)
         return record["id"]
 
+    def records(self) -> List[Dict[str, Any]]:
+        """All stored records in insertion order (copies)."""
+        with self._lock:
+            return [dict(record) for record in self._records]
+
     def search(self, query: str, k: int = 5,
                min_score: float = 0.05) -> List[Dict[str, Any]]:
         """Top-k most similar memories, newest first among ties."""

--- a/services/simulator.py
+++ b/services/simulator.py
@@ -60,6 +60,11 @@ class ReceptionPredictor:
         hour_estimate = self._shrunk_mean(hour_scores, global_mean)
         predicted = 0.6 * topic_estimate + 0.4 * hour_estimate
 
+        # Self-calibration: past predicted-vs-actual pairs correct the
+        # forecaster's systematic bias, shrunk while evidence is thin.
+        bias = self._bias_correction(scored)
+        predicted += bias
+
         evidence = len(topic_scores) + len(hour_scores)
         confidence = round(min(evidence / 20.0, 1.0), 3)
 
@@ -73,7 +78,43 @@ class ReceptionPredictor:
                 "hour": len(hour_scores),
             },
             "global_mean": round(global_mean, 3),
+            "bias_correction": round(bias, 4),
         }
+
+    def prediction_accuracy(self, session: Any) -> Dict[str, Any]:
+        """How well have past forecasts matched reality?"""
+        pairs = self._scored_pairs(session)
+        if not pairs:
+            return {"pairs": 0, "mean_error": None, "mean_abs_error": None}
+        errors = [actual - predicted for predicted, actual in pairs]
+        return {
+            "pairs": len(pairs),
+            "mean_error": round(mean(errors), 4),
+            "mean_abs_error": round(mean(abs(e) for e in errors), 4),
+        }
+
+    def _scored_pairs(self, session: Any) -> List[tuple]:
+        tweets = (
+            session.query(Tweet)
+            .filter(
+                lambda t: t.predicted_j is not None,
+                lambda t: t.j_score is not None,
+            )
+            .all()
+        )
+        return [(t.predicted_j, t.j_score) for t in tweets]
+
+    def _bias_correction(self, scored: List[Tweet]) -> float:
+        pairs = [
+            (t.predicted_j, t.j_score)
+            for t in scored
+            if t.predicted_j is not None
+        ]
+        if not pairs:
+            return 0.0
+        raw_bias = mean(actual - predicted for predicted, actual in pairs)
+        weight = len(pairs) / (len(pairs) + self.shrinkage)
+        return raw_bias * weight
 
     def _shrunk_mean(self, scores: List[float], global_mean: float) -> float:
         """Sample mean pulled toward the global mean when evidence is thin."""

--- a/tests/test_advantages.py
+++ b/tests/test_advantages.py
@@ -1,0 +1,162 @@
+"""Tests for the compounding advantages: calibration, relationship-aware
+replies, and the evidence library."""
+
+from db.models import Tweet
+from db.session import get_db_session, init_db
+from services.evidence_library import EvidenceLibrary
+from services.simulator import ReceptionPredictor
+
+
+# ---------------------------------------------------------------------- #
+# Evidence library
+# ---------------------------------------------------------------------- #
+def test_evidence_records_once_and_recalls_by_topic(tmp_path):
+    library = EvidenceLibrary(path=str(tmp_path / "evidence.jsonl"))
+
+    first = library.record(
+        url="https://www.reuters.com/energy/grid-report",
+        topic="energy",
+        context="grid interconnection queues doubled",
+    )
+    duplicate = library.record(
+        url="https://www.reuters.com/energy/grid-report",
+        topic="energy",
+    )
+    library.record(url="https://apnews.com/governance-piece", topic="governance")
+
+    assert first is not None
+    assert duplicate is None  # same URL banks only once
+    assert len(library) == 2
+
+    hits = library.recall("energy grid", k=2)
+    assert hits and hits[0]["url"] == "https://www.reuters.com/energy/grid-report"
+
+
+def test_evidence_survives_restart(tmp_path):
+    path = str(tmp_path / "evidence.jsonl")
+    EvidenceLibrary(path=path).record(url="https://apnews.com/x", topic="energy")
+
+    reloaded = EvidenceLibrary(path=path)
+    assert len(reloaded) == 1
+    # Dedupe knowledge survives too.
+    assert reloaded.record(url="https://apnews.com/x", topic="energy") is None
+
+
+def test_validated_proposals_bank_their_citations(tmp_path, monkeypatch):
+    from services import evidence_library as el_module
+    from unittest.mock import AsyncMock, MagicMock
+    from services.generator import Generator
+
+    isolated = EvidenceLibrary(path=str(tmp_path / "evidence.jsonl"))
+    monkeypatch.setattr(el_module, "_SHARED_LIBRARY", isolated)
+
+    persona_store = MagicMock()
+    persona_store.get_current_persona.return_value = {"templates": {}}
+    generator = Generator(persona_store, AsyncMock())
+
+    content = (
+        "Problem: grid queues. Mechanism: shared dispatch. Pilot: 30 days. "
+        "KPI: 20% fewer delays. Risk: adoption. Rollback: revert. "
+        "Uncertainty noted. CTA: join. https://www.reuters.com/energy/grid"
+    )
+    init_db()
+
+    import asyncio
+
+    async def run():
+        with get_db_session() as session:
+            return await generator._validate_and_refine(
+                content, "proposal", "energy", session, 1
+            )
+
+    loop = asyncio.new_event_loop()
+    try:
+        result = loop.run_until_complete(run())
+    finally:
+        loop.close()
+
+    assert "error" not in result
+    assert len(isolated) == 1
+    assert isolated.recall("energy", k=1)[0]["url"].startswith("https://www.reuters.com")
+
+
+# ---------------------------------------------------------------------- #
+# Prediction calibration
+# ---------------------------------------------------------------------- #
+def _seed_scored(session, n, predicted, actual, topic="energy", hour=9):
+    for i in range(n):
+        session.add(Tweet(
+            id=f"{topic}{hour}{predicted}{i}", text="x", kind="proposal",
+            topic=topic, hour_bin=hour, j_score=actual, predicted_j=predicted,
+        ))
+    session.commit()
+
+
+def test_bias_correction_learns_from_past_errors():
+    init_db()
+    predictor = ReceptionPredictor(min_samples=5, shrinkage=3.0)
+
+    with get_db_session() as session:
+        # History: we consistently predicted 0.4 but reality was 0.6.
+        _seed_scored(session, 8, predicted=0.4, actual=0.6)
+
+        result = predictor.predict(session, topic="energy", hour=9)
+
+    # The correction pushes the forecast above the raw historical mean.
+    assert result["bias_correction"] > 0.1
+    assert result["predicted_j"] > 0.6
+
+
+def test_prediction_accuracy_summary():
+    init_db()
+    predictor = ReceptionPredictor()
+
+    with get_db_session() as session:
+        _seed_scored(session, 4, predicted=0.5, actual=0.7)
+        accuracy = predictor.prediction_accuracy(session)
+
+    assert accuracy["pairs"] == 4
+    assert abs(accuracy["mean_error"] - 0.2) < 1e-6
+    assert abs(accuracy["mean_abs_error"] - 0.2) < 1e-6
+
+
+def test_accuracy_empty_without_scored_pairs():
+    init_db()
+    predictor = ReceptionPredictor()
+    with get_db_session() as session:
+        assert predictor.prediction_accuracy(session)["pairs"] == 0
+
+
+# ---------------------------------------------------------------------- #
+# Relationship-aware replies
+# ---------------------------------------------------------------------- #
+def test_reply_prompt_includes_relationship_history():
+    from unittest.mock import AsyncMock, MagicMock
+    from services.generator import Generator
+
+    persona_store = MagicMock()
+    persona_store.get_current_persona.return_value = {"templates": {"reply": "t"}, "tone_rules": {}}
+    persona_store.get_reply_style_override.return_value = ""
+    generator = Generator(persona_store, AsyncMock())
+
+    context = {
+        "original_tweet": "what about queue reform?",
+        "author_info": {"username": "gridwonk"},
+        "relationship": {
+            "handle": "gridwonk",
+            "interactions": 4,
+            "sentiment": 0.35,
+            "topics": ["transmission", "energy"],
+        },
+    }
+    prompt = generator._build_reply_prompt(context, {}, 1)
+
+    assert "4 prior interactions" in prompt
+    assert "+0.35" in prompt
+    assert "transmission, energy" in prompt
+
+    # Without history, no fabricated familiarity.
+    bare = generator._build_reply_prompt(
+        {"original_tweet": "hi", "author_info": {"username": "new"}}, {}, 1
+    )
+    assert "prior interactions" not in bare


### PR DESCRIPTION
## Summary

Three advantage loops that compound the longer the agent runs — each one turns data the agent already produces into sharper future behavior. No new external surface area, no new permissions; every loop feeds off already-gated, already-ledgered activity.

### 1. Self-calibrating reception forecaster
- Each published proposal now stores its forecast on the tweet itself (`Tweet.predicted_j`), so every post becomes a scored prediction once its real `j_score` lands.
- `ReceptionPredictor` learns from its own track record: a shrinkage-weighted bias correction (`_bias_correction`) nudges future forecasts by the mean signed error of past predictions — consistently underestimating reception pushes forecasts up, and vice versa.
- `prediction_accuracy()` summarizes forecast quality (pairs, mean error, mean absolute error); the nightly reflection ledgers it as `prediction_accuracy`, so calibration drift is auditable in the tamper-evident chain.

### 2. Relationship-aware replies
- `reply_mentions_job` looks up the account's `Relationship` record (interaction count, sentiment running average, topics) and passes it into generation context.
- `_build_reply_prompt` renders that history into the prompt ("4 prior interactions, sentiment trend +0.35, topics they care about: transmission, energy") so replies are consistent with the actual history — and deliberately omits the block for unknown accounts, so no fabricated familiarity.

### 3. Evidence library (`services/evidence_library.py`)
- Trusted URLs that survive the full validation pipeline are banked once (URL-deduped) into a durable semantic store (`data/evidence_library.jsonl`, `EVIDENCE_LIBRARY_PATH`).
- Proposal prompts recall topic-relevant banked citations as "Verified sources you may cite (already vetted)" — the agent accumulates a private, pre-vetted citation corpus instead of re-vetting from scratch.
- `SemanticIndex` gains a public `records()` accessor to support rebuilding the dedupe set on restart.

## Testing
- `python -m pytest`: **172 passed** (new `tests/test_advantages.py`: evidence dedupe/restart/banking-through-the-generator, bias-correction learning, accuracy summary, relationship prompt block present/absent).
- `conftest.py` isolates `EVIDENCE_LIBRARY_PATH` into a temp dir; `.gitignore` excludes the runtime `data/evidence_library.jsonl`.
- Docs updated: `docs/SAFETY_AND_ROLLOUT.md` (new ledger events), `replit.md` (capabilities + test count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnM7HbkV5ouKu3WST9v7fW

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnM7HbkV5ouKu3WST9v7fW)_