### PR TITLE
Control spine: operator approval line + Instinct Engine / Identity Gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,5 +71,14 @@ RATE_GOVERNOR_MAX_PER_HOUR=30
 DB_SNAPSHOT_PATH=data/agent_store.jsonl
 PERSIST_STORE=true
 
+# === Operator approval line (optional SMS via Twilio) ===
+# Leave blank to use the dashboard approval inbox only.
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_FROM=
+OPERATOR_PHONE=
+# Public URL Twilio posts inbound SMS to (used for signature validation)
+TWILIO_WEBHOOK_URL=
+
 # === Tooling ===
 PYTHON_PATH=python3

--- a/app.py
+++ b/app.py
@@ -39,6 +39,7 @@ from services.optimizer import Optimizer
 from services.self_model import SelfModelService
 from services.reflection import ReflectionService
 from services.ledger import get_kill_switch, get_ledger
+from services.operator_line import get_operator_line, validate_twilio_signature
 from services.security import (
     RequestContext,
     get_request_context,
@@ -130,6 +131,9 @@ class DecisionRequest(BaseModel):
 
 class TokenRequest(BaseModel):
     admin_token: str
+
+class OperatorCommandRequest(BaseModel):
+    command: str
 
 # WebSocket endpoint for real-time updates
 @app.websocket("/ws")
@@ -653,6 +657,84 @@ async def decide_goal_proposal(
     except Exception as e:
         logger.error(f"Goal proposal decision error: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/api/operator/requests")
+async def list_operator_requests(status_filter: str = "pending", _: RequestContext = Depends(get_request_context)):
+    """The operator's approval inbox (dashboard fallback for SMS)."""
+    try:
+        with get_db_session() as session:
+            requests = (
+                session.query(ApprovalRequest)
+                .filter(lambda r: r.status == status_filter)
+                .order_by(lambda r: r.created_at, descending=True)
+                .all()
+            )
+            return {
+                "count": len(requests),
+                "requests": [
+                    {
+                        "id": r.id,
+                        "kind": r.kind,
+                        "summary": r.summary,
+                        "rationale": r.rationale,
+                        "payload": r.payload,
+                        "status": r.status,
+                        "created_at": r.created_at.isoformat(),
+                    }
+                    for r in requests
+                ],
+            }
+    except Exception as e:
+        logger.error(f"Operator request list error: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/api/operator/command")
+async def operator_command(
+    request: OperatorCommandRequest,
+    _: RequestContext = Depends(require_role("admin")),
+):
+    """Run an operator command (YES/NO/EDIT/WHY/HOLD/FREEZE/NEWS/INTERVIEW/
+    OPINION) from the dashboard."""
+    try:
+        with get_db_session() as session:
+            result = get_operator_line().handle_command(session, request.command, via="dashboard")
+        return result
+    except Exception as e:
+        logger.error(f"Operator command error: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/api/operator/sms")
+async def operator_sms_webhook(request: Request):
+    """Twilio inbound-SMS webhook. Only signed requests from the configured
+    operator phone are honored; everything else is rejected before parsing
+    reaches any agent logic."""
+    from urllib.parse import parse_qs
+
+    raw = (await request.body()).decode("utf-8", errors="replace")
+    params = {k: v[0] for k, v in parse_qs(raw, keep_blank_values=True).items()}
+
+    url = os.getenv("TWILIO_WEBHOOK_URL") or str(request.url)
+    signature = request.headers.get("X-Twilio-Signature", "")
+    if not validate_twilio_signature(url, params, signature):
+        logger.warning("Rejected SMS webhook: bad Twilio signature")
+        raise HTTPException(status_code=403, detail="Invalid signature")
+
+    operator_phone = os.getenv("OPERATOR_PHONE", "")
+    if not operator_phone or params.get("From") != operator_phone:
+        logger.warning("Rejected SMS webhook: sender is not the operator")
+        raise HTTPException(status_code=403, detail="Unknown sender")
+
+    with get_db_session() as session:
+        result = get_operator_line().handle_command(session, params.get("Body", ""), via="sms")
+
+    from fastapi.responses import Response as PlainResponse
+    from xml.sax.saxutils import escape
+
+    twiml = f"<?xml version='1.0' encoding='UTF-8'?><Response><Message>{escape(result['reply'])}</Message></Response>"
+    return PlainResponse(content=twiml, media_type="application/xml")
 
 
 @app.get("/r/{redirect_id}")

--- a/db/models.py
+++ b/db/models.py
@@ -232,6 +232,37 @@ class GoalProposal:
 
 
 @dataclass
+class ApprovalRequest:
+    """A request for operator judgment, answered by SMS or the dashboard.
+
+    ``YES`` approves exactly this request (bound by id) — approval never
+    widens standing autonomy.
+    """
+
+    id: str = field(default_factory=_uuid)
+    kind: str = ""  # "publish" | "identity_gate" | "instinct" | ...
+    summary: str = ""
+    payload: Dict[str, Any] = field(default_factory=dict)
+    rationale: str = ""
+    status: str = "pending"  # pending | approved | rejected | edited | held | expired
+    created_at: datetime = field(default_factory=_utcnow)
+    decided_at: Optional[datetime] = None
+    decided_via: Optional[str] = None  # "sms" | "dashboard"
+
+
+@dataclass
+class SelfSignal:
+    """An operator-supplied thought (OPINION command). A signal to weigh,
+    never automatic doctrine."""
+
+    id: str = field(default_factory=_uuid)
+    text: str = ""
+    source: str = "operator_opinion"
+    topics: List[str] = field(default_factory=list)
+    created_at: datetime = field(default_factory=_utcnow)
+
+
+@dataclass
 class PersonaVersion:
     """Persona version history with audit trail."""
 
@@ -260,5 +291,7 @@ __all__ = [
     "Conversion",
     "DiscoveryProposal",
     "GoalProposal",
+    "ApprovalRequest",
+    "SelfSignal",
     "PersonaVersion",
 ]

--- a/docs/SAFETY_AND_ROLLOUT.md
+++ b/docs/SAFETY_AND_ROLLOUT.md
@@ -31,7 +31,9 @@ Events currently chained: `startup`, `publish_attempt` / `publish_gated` /
 `revenue_event` / `link_click`, `discovery_proposal` /
 `discovery_decision`, `okr_proposal` / `okr_decision`, `memory_consolidated` (dream
 consolidation), `reception_prediction` / `prediction_accuracy` (self-calibrating simulator),
-`admin_token_issued` (dashboard admin sessions), and
+`admin_token_issued` (dashboard admin sessions),
+`operator_prompted` / `operator_command` (operator approval line),
+`instinct_verdict` / `identity_gate` (the reflex layer), and
 `constitution_hash` / `constitution_tampered` / `constitution_missing`.
 
 The app verifies the chain at startup (`app.py`); a broken chain disarms
@@ -68,6 +70,45 @@ The mind widens itself only through gates a human holds:
 - **Goals**: the planner files OKR adjustments as ledgered `GoalProposal`s.
   The active OKR is the latest human-approved proposal (else the default),
   decided via `POST /api/goals/proposals/{id}/decision`.
+
+### Operator approval line (`services/operator_line.py`)
+When the agent needs judgment rather than rules, it files an
+`ApprovalRequest` and prompts the operator — by SMS when Twilio is
+configured (`TWILIO_ACCOUNT_SID` / `TWILIO_AUTH_TOKEN` / `TWILIO_FROM` /
+`OPERATOR_PHONE`), and always in the dashboard inbox
+(`GET /api/operator/requests`). Commands run through one parser whether they
+arrive as a signed Twilio webhook (`POST /api/operator/sms`, signature- and
+sender-validated before anything is parsed) or from the dashboard
+(`POST /api/operator/command`, admin JWT):
+
+`YES [id]`, `NO [id]`, `EDIT [id] <text>`, `WHY [id]`, `HOLD [id]`,
+`FREEZE`, `NEWS`, `INTERVIEW`, `OPINION: <thought>`
+
+Three rules are load-bearing: **YES approves exactly one request** (bound to
+its id; a bare YES refuses to act when more than one request is pending) and
+never enables standing autonomy; **FREEZE disarms outbound action
+immediately** through the kill switch; **OPINION becomes a `SelfSignal`** —
+a signal the agent weighs, never automatic doctrine. Every prompt and
+command is ledgered (`operator_prompted` / `operator_command`).
+
+### Instinct Engine and Identity Gate (`services/instinct.py`)
+A deterministic reflex layer that runs on every posting path, before and
+after generation:
+
+- **Instinct Engine** (pre-generation) scores each opportunity — identity
+  fit, mission fit, business leverage, relationship value, credibility risk,
+  ragebait risk, evidence need — and returns one of `engage`, `ignore`,
+  `save_for_later`, `research_first`, `human_review`, `block`, `dm_instead`,
+  `create_asset`. Ragebait and insults are blocked before a single token is
+  generated; hostile relationships get de-escalated privately instead of
+  publicly; high-stakes opportunities file an operator approval request.
+- **Identity Gate** (post-generation) scores the draft — belief fit, voice
+  fit, mission fit, credibility risk, drift risk — and returns `allow`,
+  `rewrite` (one regeneration attempt), `block`, or `needs_human` (files an
+  `ApprovalRequest`). Drafts with unsourced strong claims stop here.
+
+Both layers only narrow what the existing gates may see; they never publish.
+Every verdict is ledgered (`instinct_verdict` / `identity_gate`).
 
 ### Inbound senses
 The `dm_ingest` job reads incoming DMs (read-only, safe in any LIVE state).

--- a/replit.md
+++ b/replit.md
@@ -152,6 +152,8 @@ The architecture prioritizes modularity, safety, and autonomous operation while 
 - **Internal simulator**: advisory reception prediction (topic/hour history with shrinkage) ledgered as `reception_prediction` before each proposal publish; forecasts are stored on the Tweet (`predicted_j`), audited nightly (`prediction_accuracy`), and self-calibrate against past errors.
 - **Evidence library** (`data/evidence_library.jsonl`): trusted citations from validated content are banked once and recalled by topic into proposal prompts as pre-vetted sources.
 - **Relationship-aware replies**: reply prompts include the account's interaction history, sentiment trend, and topics from social memory.
+- **Operator approval line** (`services/operator_line.py`): the agent texts the operator (Twilio, optional) or files to a dashboard inbox when judgment is required; commands YES/NO/EDIT/WHY/HOLD/FREEZE/NEWS/INTERVIEW/OPINION. YES approves exactly one request; FREEZE disarms outbound instantly; OPINION becomes a self-signal, never doctrine.
+- **Instinct Engine + Identity Gate** (`services/instinct.py`): a deterministic reflex layer before and after generation — blocks ragebait/insults pre-generation, moves hostile threads to DMs, escalates high-stakes calls and unsourced claims to the operator, and rejects drafts that drift from the persona's voice or constitution.
 
 ### Testing
 - `python -m pytest` (172 tests) and `npm run check` must pass; `tests/stubs/` provides offline fallbacks for third-party packages.

--- a/runner.py
+++ b/runner.py
@@ -41,6 +41,11 @@ from services.ledger import get_kill_switch, get_ledger
 from services.simulator import ReceptionPredictor
 from services.thought_dsl import ThoughtPlan, ThoughtInterpreter
 from services.world_model import get_world_model
+from services.instinct import (
+    ALLOW, BLOCK, DM_INSTEAD, HUMAN_REVIEW, NEEDS_HUMAN, PROCEED_VERDICTS,
+    REWRITE, InstinctEngine, IdentityGate,
+)
+from services.operator_line import get_operator_line
 
 logger = get_logger(__name__)
 
@@ -76,6 +81,9 @@ heartbeat = Heartbeat(get_kill_switch(), get_ledger())
 constitution_guard = ConstitutionGuard(ledger=get_ledger(), kill_switch=get_kill_switch())
 consolidation_service = ConsolidationService(llm_adapter, ledger=get_ledger())
 reception_predictor = ReceptionPredictor()
+instinct_engine = InstinctEngine(persona_store)
+identity_gate = IdentityGate(persona_store)
+operator_line = get_operator_line()
 
 # Track pagination cursors for perception ingest to avoid refetching.
 _perception_state: Dict[str, Any] = {}
@@ -255,6 +263,37 @@ async def _add_jobs():
         max_instances=1
     )
 
+async def _gate_draft(content: str, kind: str, context: Dict[str, Any], regenerate=None) -> Optional[str]:
+    """Run a draft through the Identity Gate. ``rewrite`` gets one
+    regeneration attempt; ``needs_human`` files an operator approval request;
+    ``block`` (or a failed rewrite) drops the draft. Returns the publishable
+    content or None."""
+    review = identity_gate.review(content, kind, context)
+    if review["outcome"] == REWRITE and regenerate is not None:
+        retry = await regenerate()
+        if retry and "error" not in retry:
+            content = retry["content"]
+            review = identity_gate.review(content, kind, context)
+    if review["outcome"] == ALLOW:
+        return content
+    if review["outcome"] == NEEDS_HUMAN:
+        try:
+            with get_db_session() as session:
+                operator_line.request_approval(
+                    session,
+                    kind="publish",
+                    summary=f"{kind} draft on '{context.get('topic', '')}' needs your call",
+                    payload={"content": content, "kind": kind, "topic": context.get("topic")},
+                    rationale=review["reason"],
+                )
+        except Exception as exc:
+            logger.error(f"Failed to file approval request: {exc}")
+        logger.info("Draft escalated to operator: %s", review["reason"])
+        return None
+    logger.info("Identity gate stopped %s draft: %s", kind, review["reason"])
+    return None
+
+
 async def post_proposal_job():
     """Generate and post a proposal tweet"""
     try:
@@ -268,14 +307,42 @@ async def post_proposal_job():
             logger.info("Selector chose different action, skipping proposal")
             return
 
-        # Generate proposal
         topic = action.get("topic", "general")
         intensity = action.get("intensity", config.MIN_INTENSITY_LEVEL)
+
+        # Instinct reflex: is this opportunity worth the identity's time?
+        instinct = instinct_engine.assess({"kind": "proposal", "topic": topic})
+        if instinct["verdict"] == HUMAN_REVIEW:
+            with get_db_session() as session:
+                operator_line.request_approval(
+                    session,
+                    kind="instinct",
+                    summary=f"Proposal slot on '{topic}' flagged for review",
+                    payload={"topic": topic},
+                    rationale=instinct["reason"],
+                )
+            return
+        if instinct["verdict"] not in PROCEED_VERDICTS:
+            logger.info(
+                "Instinct %s on proposal topic '%s': %s",
+                instinct["verdict"], topic, instinct["reason"],
+            )
+            return
+
         result = await generator.make_proposal(topic, intensity)
 
         if "error" in result:
             logger.error(f"Proposal generation failed: {result['error']}")
             return
+
+        # Identity gate: does this draft sound like us and serve the mission?
+        content = await _gate_draft(
+            result["content"], "proposal", {"topic": topic},
+            regenerate=lambda: generator.make_proposal(topic, intensity),
+        )
+        if content is None:
+            return
+        result["content"] = content
 
         # Run the outbound content through the inspectable reasoning gate:
         # the plan (and the exact gate decision) lands in the decision ledger
@@ -429,13 +496,53 @@ async def reply_mentions_job():
                         "topics": list(rel.topics),
                     }
 
+                # Instinct reflex on the inbound mention before spending a reply.
+                instinct = instinct_engine.assess({
+                    "kind": "mention",
+                    "topic": topic,
+                    "text": mention.get("text", ""),
+                    "relationship": context.get("relationship"),
+                })
+                if instinct["verdict"] == HUMAN_REVIEW:
+                    with get_db_session() as session:
+                        operator_line.request_approval(
+                            session,
+                            kind="instinct",
+                            summary=f"Mention from @{mention.get('username', '?')} flagged for review",
+                            payload={"mention_id": mention["id"], "topic": topic},
+                            rationale=instinct["reason"],
+                        )
+                    continue
+                if instinct["verdict"] == DM_INSTEAD:
+                    logger.info(
+                        "Instinct: de-escalate @%s privately (value_dm owns that), skipping public reply",
+                        mention.get("username", "?"),
+                    )
+                    continue
+                if instinct["verdict"] not in PROCEED_VERDICTS:
+                    logger.info(
+                        "Instinct %s on mention from @%s: %s",
+                        instinct["verdict"], mention.get("username", "?"), instinct["reason"],
+                    )
+                    continue
+
                 intensity = action.get("intensity", config.MIN_INTENSITY_LEVEL)
                 result = await generator.make_reply(context, intensity)
-                
+
                 if "error" in result:
                     logger.warning(f"Reply generation failed: {result['error']}")
                     continue
-                
+
+                # Identity gate on the drafted reply.
+                gated = await _gate_draft(
+                    result["content"], "reply",
+                    {"topic": topic, "author": mention.get("username")},
+                    regenerate=lambda: generator.make_reply(context, intensity),
+                )
+                if gated is None:
+                    continue
+                result["content"] = gated
+
                 publish_result = await multiplexer.publish(
                     result["content"],
                     kind="reply",

--- a/services/instinct.py
+++ b/services/instinct.py
@@ -1,0 +1,318 @@
+"""Instinct Engine and Identity Gate: the agent's hard reflex layer.
+
+The Instinct Engine runs *before generation* on an opportunity (a mention, a
+proposal slot, a DM, a sensed article) and answers "should I even engage, and
+how?". The Identity Gate runs *after generation* on the draft and answers
+"is this me, and is it safe to say?". Both are deterministic heuristics
+(persona- and constitution-derived) so they work offline and are cheap enough
+to run on every action; every verdict is ledgered.
+
+Neither layer publishes anything — they only narrow what the existing
+publish gates are allowed to see. The model may recommend; application code
+authorizes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Set
+
+from services.ledger import DecisionLedger, get_ledger
+from services.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+# Instinct verdicts, roughly ordered from "act" to "don't".
+ENGAGE = "engage"
+CREATE_ASSET = "create_asset"
+RESEARCH_FIRST = "research_first"
+DM_INSTEAD = "dm_instead"
+SAVE_FOR_LATER = "save_for_later"
+HUMAN_REVIEW = "human_review"
+IGNORE = "ignore"
+BLOCK = "block"
+
+# Identity gate outcomes.
+ALLOW = "allow"
+REWRITE = "rewrite"
+NEEDS_HUMAN = "needs_human"
+# BLOCK is shared.
+
+# Verdicts that let a proposal/reply flow continue toward generation.
+PROCEED_VERDICTS = {ENGAGE, CREATE_ASSET, RESEARCH_FIRST}
+
+_DEFAULT_MISSION_KEYWORDS: Set[str] = {
+    "system", "systems", "systemic", "incentive", "incentives", "pilot",
+    "pilots", "evidence", "coordination", "science", "technology", "policy",
+    "progress", "reform", "mechanism", "institution", "institutions",
+    "infrastructure", "climate", "energy", "governance", "critical",
+    "thinking",
+}
+
+_RAGEBAIT_MARKERS = [
+    "rt if", "like if", "retweet if", "you won't believe", "destroyed",
+    "obliterated", "wake up sheeple", "ratio", "triggered", "owned",
+]
+
+_INSULT_MARKERS = [
+    "idiot", "stupid", "moron", "loser", "clown", "pathetic", "dumb",
+    "imbecile", "fool",
+]
+
+_DECEPTION_MARKERS = [
+    "i am a human", "i'm a human", "pretend to be", "as a real person",
+    "hide that i", "don't reveal",
+]
+
+_STRONG_CLAIM_MARKERS = [
+    "always", "never", "guaranteed", "100%", "everyone knows", "obviously",
+    "proven fact", "no doubt", "undeniable",
+]
+
+_SOURCE_MARKERS = ["http://", "https://", "source:", "per the", "according to"]
+
+_ASSET_MARKERS = [
+    "how do i", "how to", "guide", "template", "checklist", "tutorial",
+    "walk me through", "step by step",
+]
+
+_LEVERAGE_MARKERS = [
+    "pilot", "partner", "collaborate", "hire", "budget", "fund", "invest",
+    "procurement", "rfp", "deal", "contract",
+]
+
+
+def _caps_ratio(text: str) -> float:
+    letters = [c for c in text if c.isalpha()]
+    if len(letters) < 15:
+        return 0.0
+    return sum(1 for c in letters if c.isupper()) / len(letters)
+
+
+def _marker_score(text: str, markers: List[str], per_hit: float = 0.3) -> float:
+    return min(1.0, sum(per_hit for marker in markers if marker in text))
+
+
+def _overlap(text: str, keywords: Set[str]) -> float:
+    words = {w.strip(".,!?;:()\"'") for w in text.split() if w.strip()}
+    if not words:
+        return 0.0
+    hits = len(words & keywords)
+    # Short inputs (a bare topic) are judged against their own length so a
+    # single on-mission word scores as a full match.
+    return min(1.0, hits / min(3, len(words)))
+
+
+class _PersonaMixin:
+    def __init__(self, persona_store: Any = None, ledger: Optional[DecisionLedger] = None):
+        self.persona_store = persona_store
+        self._ledger = ledger
+
+    @property
+    def ledger(self) -> DecisionLedger:
+        return self._ledger or get_ledger()
+
+    def _mission_keywords(self) -> Set[str]:
+        keywords = set(_DEFAULT_MISSION_KEYWORDS)
+        if self.persona_store is None:
+            return keywords
+        try:
+            persona = self.persona_store.get_current_persona()
+            for source in (
+                persona.get("mission", ""),
+                " ".join(persona.get("engagement_focus", [])),
+                " ".join(persona.get("doctrine", [])),
+            ):
+                for word in str(source).lower().split():
+                    word = word.strip(".,!?;:()\"'")
+                    if len(word) > 3:
+                        keywords.add(word)
+        except Exception:
+            pass
+        return keywords
+
+
+class InstinctEngine(_PersonaMixin):
+    """Pre-generation reflex: is this opportunity worth this identity's time?"""
+
+    def assess(self, opportunity: Dict[str, Any]) -> Dict[str, Any]:
+        kind = opportunity.get("kind", "unknown")
+        topic = str(opportunity.get("topic") or "")
+        text = str(opportunity.get("text") or "")
+        combined = f"{topic} {text}".lower()
+        relationship = opportunity.get("relationship") or {}
+
+        ragebait_risk = _marker_score(combined, _RAGEBAIT_MARKERS)
+        if _caps_ratio(text) > 0.5:
+            ragebait_risk = min(1.0, ragebait_risk + 0.4)
+        insulting = any(marker in combined for marker in _INSULT_MARKERS)
+
+        credibility_risk = _marker_score(combined, _STRONG_CLAIM_MARKERS, per_hit=0.25)
+        has_source = any(marker in combined for marker in _SOURCE_MARKERS)
+        has_figures = any(c.isdigit() for c in combined)
+        if has_figures and not has_source:
+            credibility_risk = min(1.0, credibility_risk + 0.3)
+
+        evidence_need = 0.0
+        if has_figures:
+            evidence_need += 0.3
+        if any(w in combined for w in ("study", "studies", "data", "research", "report")):
+            evidence_need += 0.3
+        if has_source:
+            evidence_need -= 0.4
+        evidence_need = max(0.0, min(1.0, evidence_need))
+
+        keywords = self._mission_keywords()
+        mission_fit = _overlap(combined, keywords)
+        # The selector's default slot ("general") means "persona's choice" —
+        # neutral fit, not off-mission.
+        if kind == "proposal" and not text and topic.strip().lower() in ("", "general"):
+            mission_fit = max(mission_fit, 0.5)
+        identity_fit = mission_fit  # one persona, one lens; kept as separate
+        # signals so future scoring can diverge them.
+
+        interactions = relationship.get("interactions", 0) or 0
+        sentiment = relationship.get("sentiment", 0.0) or 0.0
+        relationship_value = min(1.0, interactions * 0.15 + max(0.0, sentiment) * 0.3)
+
+        business_leverage = _marker_score(combined, _LEVERAGE_MARKERS)
+
+        scores = {
+            "identity_fit": round(identity_fit, 3),
+            "mission_fit": round(mission_fit, 3),
+            "business_leverage": round(business_leverage, 3),
+            "relationship_value": round(relationship_value, 3),
+            "credibility_risk": round(credibility_risk, 3),
+            "ragebait_risk": round(ragebait_risk, 3),
+            "evidence_need": round(evidence_need, 3),
+        }
+
+        verdict, reason = self._verdict(
+            kind, scores, insulting=insulting, sentiment=sentiment,
+            combined=combined, stakes=opportunity.get("stakes"),
+        )
+
+        result = {"verdict": verdict, "reason": reason, "scores": scores, "kind": kind}
+        try:
+            self.ledger.record("instinct_verdict", {
+                "kind": kind, "topic": topic[:60], "verdict": verdict,
+                "reason": reason, **scores,
+            })
+        except Exception as exc:
+            logger.error(f"Failed to ledger instinct verdict: {exc}")
+        return result
+
+    def _verdict(self, kind, scores, *, insulting, sentiment, combined, stakes):
+        if scores["ragebait_risk"] >= 0.6:
+            return BLOCK, "reads as ragebait; engaging feeds it"
+        if insulting:
+            return BLOCK, "engaging with insults degrades the identity"
+        if kind == "mention" and sentiment <= -0.4:
+            return DM_INSTEAD, "hostile history; de-escalate privately, not publicly"
+        if stakes == "high":
+            return HUMAN_REVIEW, "high stakes flagged; a human should look first"
+        if scores["evidence_need"] >= 0.6 and scores["credibility_risk"] >= 0.5:
+            return RESEARCH_FIRST, "factual claims need verification before engaging"
+        if any(marker in combined for marker in _ASSET_MARKERS):
+            return CREATE_ASSET, "a reusable asset serves this better than a one-off reply"
+        fit = max(scores["identity_fit"], scores["mission_fit"])
+        if fit < 0.2 and scores["relationship_value"] < 0.3:
+            return IGNORE, "off-mission and no relationship at stake"
+        # Mentions go stale and self-chosen proposal slots were already
+        # persona-picked, so "bank it" only applies to sensed material.
+        if (
+            kind not in ("mention", "proposal")
+            and fit < 0.45
+            and scores["business_leverage"] < 0.6
+        ):
+            return SAVE_FOR_LATER, "marginal fit; bank it rather than force it"
+        return ENGAGE, "on-mission and worth the identity's time"
+
+
+class IdentityGate(_PersonaMixin):
+    """Post-generation gate: is this draft consistent with who the agent is?"""
+
+    def review(self, draft: str, kind: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        context = context or {}
+        lower = draft.lower()
+
+        drift_risk = 0.0
+        if any(marker in lower for marker in _INSULT_MARKERS):
+            drift_risk += 0.8
+        if any(marker in lower for marker in _DECEPTION_MARKERS):
+            drift_risk += 0.8
+        drift_risk = min(1.0, drift_risk + _marker_score(lower, _RAGEBAIT_MARKERS, per_hit=0.2))
+
+        voice_fit = 1.0
+        if _caps_ratio(draft) > 0.3:
+            voice_fit -= 0.4
+        if draft.count("!") > 2:
+            voice_fit -= 0.2
+        if draft.count("#") > 3:
+            voice_fit -= 0.2
+        voice_fit = max(0.0, voice_fit)
+
+        keywords = self._mission_keywords()
+        overlap = _overlap(lower, keywords)
+        # Replies legitimately carry less mission vocabulary than proposals.
+        mission_fit = 0.5 + overlap * 0.5 if kind == "reply" else overlap
+        belief_fit = mission_fit
+
+        credibility_risk = _marker_score(lower, _STRONG_CLAIM_MARKERS, per_hit=0.25)
+        has_source = any(marker in lower for marker in _SOURCE_MARKERS)
+        if any(c.isdigit() for c in lower) and not has_source:
+            credibility_risk = min(1.0, credibility_risk + 0.3)
+
+        business_leverage = _marker_score(lower, _LEVERAGE_MARKERS)
+
+        scores = {
+            "belief_fit": round(belief_fit, 3),
+            "voice_fit": round(voice_fit, 3),
+            "mission_fit": round(mission_fit, 3),
+            "business_leverage": round(business_leverage, 3),
+            "credibility_risk": round(credibility_risk, 3),
+            "drift_risk": round(drift_risk, 3),
+        }
+
+        if drift_risk >= 0.6:
+            outcome, reason = BLOCK, "draft drifts from the constitution (insults/deception/ragebait)"
+        elif credibility_risk >= 0.7:
+            outcome, reason = NEEDS_HUMAN, "strong unsourced claims; a human should approve"
+        elif voice_fit < 0.5 or (kind != "reply" and mission_fit < 0.2):
+            outcome, reason = REWRITE, "doesn't sound like us or serve the mission"
+        else:
+            outcome, reason = ALLOW, "consistent with identity and mission"
+
+        result = {"outcome": outcome, "reason": reason, "scores": scores, "kind": kind}
+        try:
+            self.ledger.record("identity_gate", {
+                "kind": kind, "outcome": outcome, "reason": reason, **scores,
+            })
+        except Exception as exc:
+            logger.error(f"Failed to ledger identity gate: {exc}")
+        return result
+
+
+_SHARED_ENGINE: Optional[InstinctEngine] = None
+_SHARED_GATE: Optional[IdentityGate] = None
+
+
+def get_instinct_engine() -> InstinctEngine:
+    global _SHARED_ENGINE
+    if _SHARED_ENGINE is None:
+        _SHARED_ENGINE = InstinctEngine()
+    return _SHARED_ENGINE
+
+
+def get_identity_gate() -> IdentityGate:
+    global _SHARED_GATE
+    if _SHARED_GATE is None:
+        _SHARED_GATE = IdentityGate()
+    return _SHARED_GATE
+
+
+def set_instinct_instances(
+    engine: Optional[InstinctEngine] = None, gate: Optional[IdentityGate] = None
+) -> None:
+    global _SHARED_ENGINE, _SHARED_GATE
+    _SHARED_ENGINE = engine
+    _SHARED_GATE = gate

--- a/services/operator_line.py
+++ b/services/operator_line.py
@@ -1,0 +1,338 @@
+"""Operator approval line: a trusted human command channel.
+
+DALEOBANKS contacts the operator only when judgment is required — emergency
+approvals, freezes, news briefings, interview questions, and opinion intake.
+Commands arrive by SMS (Twilio webhook) or the dashboard; both paths run
+through :meth:`OperatorLine.handle_command`.
+
+Command grammar (first word, case-insensitive; ``<id>`` is any unique prefix
+of a request id and may be omitted when exactly one request is pending):
+
+    YES [<id>]          approve exactly that request — never standing autonomy
+    NO [<id>]           reject the request
+    EDIT [<id>] <text>  approve with the operator's replacement text
+    WHY [<id>]          explain why the agent is asking
+    HOLD [<id>]         park the request for later (YES/NO still work on it)
+    FREEZE              immediately disarm all outbound action (kill switch)
+    NEWS                a short briefing of what the agent has been sensing
+    INTERVIEW           the question the agent most wants answered right now
+    OPINION: <thought>  store the thought as a self-signal, never doctrine
+
+Every prompt and command is ledgered (``operator_prompted`` /
+``operator_command``).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import urllib.parse
+import urllib.request
+from datetime import datetime, UTC
+from typing import Any, Dict, List, Optional
+
+from db.models import ApprovalRequest, DiscoveryProposal, GoalProposal, SelfSignal, SensedEvent
+from services.ledger import DecisionLedger, KillSwitch, get_kill_switch, get_ledger
+from services.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+HELP_TEXT = (
+    "Commands: YES [id], NO [id], EDIT [id] <text>, WHY [id], HOLD [id], "
+    "FREEZE, NEWS, INTERVIEW, OPINION: <thought>"
+)
+
+_DECIDABLE = ("pending", "held")
+
+
+class OperatorLine:
+    """Sends approval prompts to the operator and executes their commands."""
+
+    def __init__(
+        self,
+        ledger: Optional[DecisionLedger] = None,
+        kill_switch: Optional[KillSwitch] = None,
+    ) -> None:
+        self._ledger = ledger
+        self._kill_switch = kill_switch
+
+    @property
+    def ledger(self) -> DecisionLedger:
+        return self._ledger or get_ledger()
+
+    @property
+    def kill_switch(self) -> KillSwitch:
+        return self._kill_switch or get_kill_switch()
+
+    # ------------------------------------------------------------------ #
+    # Outbound: asking for judgment
+    # ------------------------------------------------------------------ #
+    @property
+    def sms_configured(self) -> bool:
+        return all(
+            os.getenv(var)
+            for var in ("TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN", "TWILIO_FROM", "OPERATOR_PHONE")
+        )
+
+    def request_approval(
+        self,
+        session: Any,
+        kind: str,
+        summary: str,
+        payload: Optional[Dict[str, Any]] = None,
+        rationale: str = "",
+    ) -> ApprovalRequest:
+        """File an ApprovalRequest and prompt the operator (SMS if configured,
+        dashboard inbox always)."""
+        request = ApprovalRequest(
+            kind=kind, summary=summary, payload=payload or {}, rationale=rationale
+        )
+        session.add(request)
+        session.commit()
+
+        short = request.id[:8]
+        sms_sent = False
+        if self.sms_configured:
+            sms_sent = self._send_sms(
+                f"[DaLeoBanks] {summary} — reply YES {short} / NO {short} / WHY {short}"
+            )
+        self.ledger.record("operator_prompted", {
+            "id": request.id,
+            "kind": kind,
+            "summary": summary[:120],
+            "sms_sent": sms_sent,
+        })
+        return request
+
+    def _send_sms(self, body: str) -> bool:
+        sid = os.getenv("TWILIO_ACCOUNT_SID", "")
+        token = os.getenv("TWILIO_AUTH_TOKEN", "")
+        try:
+            data = urllib.parse.urlencode({
+                "To": os.getenv("OPERATOR_PHONE", ""),
+                "From": os.getenv("TWILIO_FROM", ""),
+                "Body": body[:1500],
+            }).encode()
+            req = urllib.request.Request(
+                f"https://api.twilio.com/2010-04-01/Accounts/{sid}/Messages.json",
+                data=data,
+                method="POST",
+            )
+            auth = base64.b64encode(f"{sid}:{token}".encode()).decode()
+            req.add_header("Authorization", f"Basic {auth}")
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return 200 <= resp.status < 300
+        except Exception as exc:
+            logger.error(f"Operator SMS send failed: {exc}")
+            return False
+
+    # ------------------------------------------------------------------ #
+    # Inbound: executing operator commands
+    # ------------------------------------------------------------------ #
+    def handle_command(self, session: Any, text: str, via: str = "dashboard") -> Dict[str, Any]:
+        raw = (text or "").strip()
+        if not raw:
+            return self._done("HELP", via, ok=False, reply=HELP_TEXT)
+
+        head, _, rest = raw.partition(" ")
+        cmd = head.upper().rstrip(":")
+        rest = rest.strip()
+
+        if cmd in ("YES", "NO", "HOLD"):
+            return self._decide(session, cmd, rest, via)
+        if cmd == "EDIT":
+            return self._edit(session, rest, via)
+        if cmd == "WHY":
+            return self._why(session, rest, via)
+        if cmd == "FREEZE":
+            self.kill_switch.set_armed(False, reason="operator_freeze")
+            return self._done(cmd, via, ok=True, reply="Frozen. All outbound action is disarmed.")
+        if cmd == "NEWS":
+            return self._done(cmd, via, ok=True, reply=self._news_briefing(session))
+        if cmd == "INTERVIEW":
+            return self._done(cmd, via, ok=True, reply=self._interview_question(session))
+        if cmd == "OPINION":
+            return self._opinion(session, rest, via)
+        return self._done(cmd, via, ok=False, reply=f"Unknown command. {HELP_TEXT}")
+
+    def _decide(self, session: Any, cmd: str, arg: str, via: str) -> Dict[str, Any]:
+        request, error = self._resolve(session, arg)
+        if request is None:
+            return self._done(cmd, via, ok=False, reply=error)
+
+        status = {"YES": "approved", "NO": "rejected", "HOLD": "held"}[cmd]
+        request.status = status
+        request.decided_at = datetime.now(UTC)
+        request.decided_via = via
+        session.commit()
+        reply = f"{status.capitalize()}: {request.summary}"
+        if cmd == "YES":
+            reply += " (this approval covers only this request)"
+        return self._done(cmd, via, ok=True, reply=reply, request_id=request.id)
+
+    def _edit(self, session: Any, rest: str, via: str) -> Dict[str, Any]:
+        maybe_id, _, text = rest.partition(" ")
+        request, _ = self._resolve(session, maybe_id) if maybe_id else (None, None)
+        if request is None:
+            # No id prefix given — the whole rest is the replacement text.
+            request, error = self._resolve(session, "")
+            text = rest
+            if request is None:
+                return self._done("EDIT", via, ok=False, reply=error)
+        text = text.strip()
+        if not text:
+            return self._done("EDIT", via, ok=False, reply="EDIT needs replacement text.")
+
+        request.payload["operator_edit"] = text
+        request.status = "edited"
+        request.decided_at = datetime.now(UTC)
+        request.decided_via = via
+        session.commit()
+        return self._done(
+            "EDIT", via, ok=True,
+            reply=f"Edited and approved with your text: {request.summary}",
+            request_id=request.id,
+        )
+
+    def _why(self, session: Any, arg: str, via: str) -> Dict[str, Any]:
+        request, error = self._resolve(session, arg)
+        if request is None:
+            return self._done("WHY", via, ok=False, reply=error)
+        reply = f"[{request.kind}] {request.summary}"
+        if request.rationale:
+            reply += f" — because: {request.rationale}"
+        content = request.payload.get("content")
+        if content:
+            reply += f' — draft: "{str(content)[:200]}"'
+        return self._done("WHY", via, ok=True, reply=reply, request_id=request.id)
+
+    def _opinion(self, session: Any, thought: str, via: str) -> Dict[str, Any]:
+        thought = thought.strip()
+        if not thought:
+            return self._done("OPINION", via, ok=False, reply="OPINION needs a thought after the colon.")
+        signal = SelfSignal(text=thought, source="operator_opinion")
+        session.add(signal)
+        session.commit()
+        return self._done(
+            "OPINION", via, ok=True,
+            reply="Recorded as a self-signal. I will weigh it, not obey it.",
+            extra={"self_signal_id": signal.id},
+        )
+
+    def _resolve(self, session: Any, arg: str):
+        """Find the request a command targets. Bare commands only work when
+        exactly one request is pending — YES can never be ambiguous."""
+        arg = (arg or "").strip().lower()
+        candidates: List[ApprovalRequest] = (
+            session.query(ApprovalRequest)
+            .filter(lambda r: r.status in _DECIDABLE)
+            .order_by(lambda r: r.created_at, descending=True)
+            .all()
+        )
+        if arg:
+            matches = [r for r in candidates if r.id.lower().startswith(arg)]
+            if len(matches) == 1:
+                return matches[0], None
+            if not matches:
+                return None, f"No open request matches '{arg}'."
+            return None, f"'{arg}' is ambiguous ({len(matches)} matches) — use more characters."
+
+        pending = [r for r in candidates if r.status == "pending"]
+        if len(pending) == 1:
+            return pending[0], None
+        if not pending:
+            return None, "No pending requests."
+        ids = ", ".join(r.id[:8] for r in pending[:5])
+        return None, f"{len(pending)} requests pending — specify one: {ids}"
+
+    # ------------------------------------------------------------------ #
+    # Briefings
+    # ------------------------------------------------------------------ #
+    def _news_briefing(self, session: Any) -> str:
+        events = (
+            session.query(SensedEvent)
+            .order_by(lambda e: e.created_at, descending=True)
+            .limit(3)
+            .all()
+        )
+        pending = session.query(ApprovalRequest).filter(lambda r: r.status == "pending").all()
+        lines = []
+        for event in events:
+            snippet = str(event.payload.get("text") or event.payload.get("query") or "")[:80]
+            lines.append(f"- {event.kind} via {event.source}: {snippet}".rstrip(": "))
+        if not lines:
+            lines.append("- Nothing sensed recently.")
+        lines.append(f"Pending approvals: {len(pending)}.")
+        from config import get_config
+        lines.append(f"Live mode: {'ARMED' if get_config().LIVE else 'disarmed'}.")
+        return "\n".join(lines)
+
+    def _interview_question(self, session: Any) -> str:
+        oldest = (
+            session.query(ApprovalRequest)
+            .filter(lambda r: r.status == "pending")
+            .order_by(lambda r: r.created_at)
+            .first()
+        )
+        if oldest:
+            return f"Decide this first: {oldest.summary} (YES {oldest.id[:8]} / NO {oldest.id[:8]})"
+        discoveries = session.query(DiscoveryProposal).filter(lambda p: p.status == "pending").all()
+        goals = session.query(GoalProposal).filter(lambda p: p.status == "pending").all()
+        if discoveries or goals:
+            return (
+                f"{len(discoveries)} discovery and {len(goals)} goal proposals await review "
+                "on the /approvals page. Which should I prioritize arguing for?"
+            )
+        return "What outcome would make the next 30 days a clear win for you?"
+
+    def _done(
+        self,
+        command: str,
+        via: str,
+        ok: bool,
+        reply: str,
+        request_id: Optional[str] = None,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        record: Dict[str, Any] = {"command": command, "via": via, "ok": ok}
+        if request_id:
+            record["request_id"] = request_id
+        if extra:
+            record.update(extra)
+        try:
+            self.ledger.record("operator_command", record)
+        except Exception as exc:
+            logger.error(f"Failed to ledger operator command: {exc}")
+        result = {"ok": ok, "reply": reply}
+        if request_id:
+            result["request_id"] = request_id
+        return result
+
+
+def validate_twilio_signature(url: str, params: Dict[str, str], signature: str) -> bool:
+    """Validate Twilio's X-Twilio-Signature header (HMAC-SHA1 over the URL
+    plus sorted POST params, keyed by the auth token)."""
+    token = os.getenv("TWILIO_AUTH_TOKEN", "")
+    if not token or not signature:
+        return False
+    payload = url + "".join(key + params[key] for key in sorted(params))
+    digest = hmac.new(token.encode(), payload.encode("utf-8"), hashlib.sha1).digest()
+    expected = base64.b64encode(digest).decode()
+    return hmac.compare_digest(expected, signature)
+
+
+_SHARED_LINE: Optional[OperatorLine] = None
+
+
+def get_operator_line() -> OperatorLine:
+    global _SHARED_LINE
+    if _SHARED_LINE is None:
+        _SHARED_LINE = OperatorLine()
+    return _SHARED_LINE
+
+
+def set_operator_line(line: Optional[OperatorLine]) -> None:
+    global _SHARED_LINE
+    _SHARED_LINE = line

--- a/tests/test_instinct.py
+++ b/tests/test_instinct.py
@@ -1,0 +1,147 @@
+"""Tests for the Instinct Engine (pre-generation reflex) and Identity Gate
+(post-generation draft review)."""
+
+from services.instinct import (
+    ALLOW, BLOCK, CREATE_ASSET, DM_INSTEAD, ENGAGE, HUMAN_REVIEW, IGNORE,
+    NEEDS_HUMAN, RESEARCH_FIRST, REWRITE, IdentityGate, InstinctEngine,
+)
+from services.ledger import DecisionLedger
+
+
+# ---------------------------------------------------------------------- #
+# Instinct Engine
+# ---------------------------------------------------------------------- #
+def test_ragebait_is_blocked():
+    verdict = InstinctEngine().assess({
+        "kind": "mention",
+        "topic": "energy",
+        "text": "RT if you agree! They DESTROYED him! Wake up sheeple!",
+    })
+    assert verdict["verdict"] == BLOCK
+    assert verdict["scores"]["ragebait_risk"] >= 0.6
+
+
+def test_insults_are_blocked():
+    verdict = InstinctEngine().assess({
+        "kind": "mention", "topic": "energy",
+        "text": "only an idiot would post this",
+    })
+    assert verdict["verdict"] == BLOCK
+
+
+def test_off_mission_stranger_is_ignored():
+    verdict = InstinctEngine().assess({
+        "kind": "mention",
+        "topic": "gossip",
+        "text": "did you watch that celebrity drama episode last night",
+    })
+    assert verdict["verdict"] == IGNORE
+
+
+def test_unsourced_claims_demand_research_first():
+    verdict = InstinctEngine().assess({
+        "kind": "proposal",
+        "topic": "energy",
+        "text": "Solar always beats nuclear, 100% guaranteed, everyone knows the data",
+    })
+    assert verdict["verdict"] == RESEARCH_FIRST
+    assert verdict["scores"]["evidence_need"] >= 0.6
+
+
+def test_hostile_history_moves_to_dm():
+    verdict = InstinctEngine().assess({
+        "kind": "mention",
+        "topic": "energy",
+        "text": "you keep dodging my question about the grid",
+        "relationship": {"interactions": 3, "sentiment": -0.6},
+    })
+    assert verdict["verdict"] == DM_INSTEAD
+
+
+def test_high_stakes_goes_to_human():
+    verdict = InstinctEngine().assess({
+        "kind": "proposal", "topic": "energy policy", "stakes": "high",
+    })
+    assert verdict["verdict"] == HUMAN_REVIEW
+
+
+def test_how_to_requests_become_assets():
+    verdict = InstinctEngine().assess({
+        "kind": "mention",
+        "topic": "energy",
+        "text": "how to structure a grid pilot for a small utility according to you",
+    })
+    assert verdict["verdict"] == CREATE_ASSET
+
+
+def test_on_mission_topic_engages_and_is_ledgered(tmp_path):
+    ledger = DecisionLedger(path=str(tmp_path / "ledger.jsonl"))
+    engine = InstinctEngine(ledger=ledger)
+
+    verdict = engine.assess({"kind": "proposal", "topic": "energy"})
+    assert verdict["verdict"] == ENGAGE
+
+    entries = ledger.replay("instinct_verdict")
+    assert entries and entries[-1]["payload"]["verdict"] == ENGAGE
+
+
+def test_default_general_slot_still_engages():
+    verdict = InstinctEngine().assess({"kind": "proposal", "topic": "general"})
+    assert verdict["verdict"] == ENGAGE
+
+
+# ---------------------------------------------------------------------- #
+# Identity Gate
+# ---------------------------------------------------------------------- #
+def test_gate_blocks_insulting_draft():
+    review = IdentityGate().review("Only an idiot would believe this take.", "reply", {})
+    assert review["outcome"] == BLOCK
+    assert review["scores"]["drift_risk"] >= 0.6
+
+
+def test_gate_blocks_deceptive_draft():
+    review = IdentityGate().review(
+        "I am a human just like you, trust me on this.", "reply", {}
+    )
+    assert review["outcome"] == BLOCK
+
+
+def test_gate_rewrites_off_voice_draft():
+    review = IdentityGate().review(
+        "THIS IS HUGE!!! CHECK IT OUT NOW!!! #wow #amazing #viral #trending",
+        "proposal", {"topic": "energy"},
+    )
+    assert review["outcome"] == REWRITE
+    assert review["scores"]["voice_fit"] < 0.5
+
+
+def test_gate_escalates_unsourced_strong_claims():
+    review = IdentityGate().review(
+        "Nuclear is always guaranteed 100% safe, everyone knows this.",
+        "proposal", {"topic": "energy"},
+    )
+    assert review["outcome"] == NEEDS_HUMAN
+    assert review["scores"]["credibility_risk"] >= 0.7
+
+
+def test_gate_allows_sourced_mission_fit_draft(tmp_path):
+    ledger = DecisionLedger(path=str(tmp_path / "ledger.jsonl"))
+    gate = IdentityGate(ledger=ledger)
+
+    review = gate.review(
+        "Problem: interconnection queues stall energy pilots. Mechanism: shared "
+        "dispatch incentives. Evidence: https://example.org/study. CTA: join the pilot.",
+        "proposal", {"topic": "energy"},
+    )
+    assert review["outcome"] == ALLOW
+
+    entries = ledger.replay("identity_gate")
+    assert entries and entries[-1]["payload"]["outcome"] == ALLOW
+
+
+def test_gate_allows_plain_reply_without_mission_vocabulary():
+    review = IdentityGate().review(
+        "Fair point — the queue history cuts both ways. What did your utility see?",
+        "reply", {},
+    )
+    assert review["outcome"] == ALLOW

--- a/tests/test_operator_line.py
+++ b/tests/test_operator_line.py
@@ -1,0 +1,163 @@
+"""Tests for the operator approval line: command semantics and safety rules."""
+
+import base64
+import hashlib
+import hmac
+
+from config import get_config, update_config
+from db.models import ApprovalRequest, SelfSignal
+from db.session import get_db_session, init_db
+from services.ledger import DecisionLedger, KillSwitch
+from services.operator_line import OperatorLine, validate_twilio_signature
+
+
+def _line(tmp_path) -> OperatorLine:
+    ledger = DecisionLedger(path=str(tmp_path / "ledger.jsonl"))
+    return OperatorLine(ledger=ledger, kill_switch=KillSwitch(ledger=ledger))
+
+
+def test_request_approval_creates_pending_and_ledgers(tmp_path):
+    init_db()
+    line = _line(tmp_path)
+    with get_db_session() as session:
+        request = line.request_approval(
+            session, kind="publish", summary="Post the grid thread?",
+            payload={"content": "draft"}, rationale="strong claims",
+        )
+        stored = session.query(ApprovalRequest).all()
+
+    assert stored and stored[0].id == request.id
+    assert stored[0].status == "pending"
+    prompts = line.ledger.replay("operator_prompted")
+    assert prompts and prompts[-1]["payload"]["id"] == request.id
+    assert prompts[-1]["payload"]["sms_sent"] is False  # no Twilio configured
+
+
+def test_yes_approves_the_single_pending_request(tmp_path):
+    init_db()
+    line = _line(tmp_path)
+    with get_db_session() as session:
+        request = line.request_approval(session, kind="publish", summary="Ship it?")
+        result = line.handle_command(session, "YES", via="sms")
+        assert result["ok"] is True
+        assert result["request_id"] == request.id
+        assert session.query(ApprovalRequest).first().status == "approved"
+        # YES covers only that request — nothing remains approved-in-advance.
+        again = line.handle_command(session, "YES", via="sms")
+        assert again["ok"] is False
+
+
+def test_bare_yes_refuses_when_ambiguous(tmp_path):
+    init_db()
+    line = _line(tmp_path)
+    with get_db_session() as session:
+        line.request_approval(session, kind="publish", summary="First?")
+        line.request_approval(session, kind="publish", summary="Second?")
+        result = line.handle_command(session, "YES")
+        assert result["ok"] is False
+        statuses = {r.status for r in session.query(ApprovalRequest).all()}
+        assert statuses == {"pending"}  # ambiguity approves nothing
+
+
+def test_yes_with_id_prefix_targets_exactly_one(tmp_path):
+    init_db()
+    line = _line(tmp_path)
+    with get_db_session() as session:
+        first = line.request_approval(session, kind="publish", summary="First?")
+        second = line.request_approval(session, kind="publish", summary="Second?")
+        result = line.handle_command(session, f"YES {first.id[:8]}")
+        assert result["ok"] is True
+
+        by_id = {r.id: r.status for r in session.query(ApprovalRequest).all()}
+        assert by_id[first.id] == "approved"
+        assert by_id[second.id] == "pending"
+
+
+def test_no_and_hold_and_edit(tmp_path):
+    init_db()
+    line = _line(tmp_path)
+    with get_db_session() as session:
+        request = line.request_approval(session, kind="publish", summary="Ship?")
+        line.handle_command(session, f"HOLD {request.id[:8]}")
+        assert session.query(ApprovalRequest).first().status == "held"
+
+        # Held requests can still be decided by id.
+        line.handle_command(session, f"NO {request.id[:8]}")
+        assert session.query(ApprovalRequest).first().status == "rejected"
+
+        second = line.request_approval(session, kind="publish", summary="Other?")
+        result = line.handle_command(session, "EDIT Use this wording instead")
+        assert result["ok"] is True
+        stored = [r for r in session.query(ApprovalRequest).all() if r.id == second.id][0]
+        assert stored.status == "edited"
+        assert stored.payload["operator_edit"] == "Use this wording instead"
+
+
+def test_freeze_disarms_outbound_immediately(tmp_path):
+    init_db()
+    line = _line(tmp_path)
+    update_config(LIVE=True)
+    try:
+        with get_db_session() as session:
+            result = line.handle_command(session, "FREEZE", via="sms")
+        assert result["ok"] is True
+        assert get_config().LIVE is False
+        commands = line.ledger.replay("operator_command")
+        assert commands[-1]["payload"]["command"] == "FREEZE"
+    finally:
+        update_config(LIVE=False)
+
+
+def test_opinion_becomes_self_signal_not_doctrine(tmp_path):
+    init_db()
+    line = _line(tmp_path)
+    with get_db_session() as session:
+        result = line.handle_command(
+            session, "OPINION: lean harder into transmission reform", via="sms"
+        )
+        signals = session.query(SelfSignal).all()
+
+    assert result["ok"] is True
+    assert len(signals) == 1
+    assert signals[0].text == "lean harder into transmission reform"
+    assert signals[0].source == "operator_opinion"
+    assert "weigh" in result["reply"]  # a signal to weigh, never to obey
+
+
+def test_why_explains_the_request(tmp_path):
+    init_db()
+    line = _line(tmp_path)
+    with get_db_session() as session:
+        line.request_approval(
+            session, kind="publish", summary="Post the claim?",
+            payload={"content": "Grid queues doubled since 2020."},
+            rationale="unsourced statistic",
+        )
+        result = line.handle_command(session, "WHY")
+
+    assert result["ok"] is True
+    assert "unsourced statistic" in result["reply"]
+    assert "Grid queues doubled" in result["reply"]
+
+
+def test_unknown_command_returns_help(tmp_path):
+    init_db()
+    line = _line(tmp_path)
+    with get_db_session() as session:
+        result = line.handle_command(session, "LAUNCH THE NUKES")
+    assert result["ok"] is False
+    assert "YES" in result["reply"] and "FREEZE" in result["reply"]
+
+
+def test_twilio_signature_validation(monkeypatch):
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "secret-token")
+    url = "https://example.com/api/operator/sms"
+    params = {"Body": "YES", "From": "+15550001111"}
+    payload = url + "Body" + "YES" + "From" + "+15550001111"
+    good = base64.b64encode(
+        hmac.new(b"secret-token", payload.encode(), hashlib.sha1).digest()
+    ).decode()
+
+    assert validate_twilio_signature(url, params, good) is True
+    assert validate_twilio_signature(url, params, "forged") is False
+    assert validate_twilio_signature(url, params, "") is False

--- a/tests/test_runner_jobs.py
+++ b/tests/test_runner_jobs.py
@@ -228,3 +228,49 @@ async def test_reply_mentions_logs_bandit_metadata(monkeypatch):
     assert stored.cta_variant == "reply_default"
     assert log_calls and log_calls[0]["post_type"] == "reply"
     assert log_calls[0]["hour_bin"] == 9
+
+
+@pytest.mark.asyncio
+async def test_reply_mentions_instinct_blocks_ragebait(monkeypatch):
+    init_db()
+
+    mention = {
+        "id": "m2",
+        "text": "RT if you agree! They DESTROYED him! Wake up sheeple!",
+        "username": "baiter",
+    }
+    generated = []
+    published = []
+
+    class FakeXClient:
+        async def get_mentions(self):
+            return [mention]
+
+    async def fake_make_reply(context, intensity):
+        generated.append(context)
+        return {"content": "engaging with the bait"}
+
+    async def fake_publish(content, **kwargs):
+        published.append(content)
+        return {"x": SocialPostResult(platform="x", post_id="r2", dry_run=False, meta={})}
+
+    async def fake_decide():
+        return {"type": "REPLY_MENTIONS", "intensity": 2, "topic": "coordination"}
+
+    previous_live = runner.config.LIVE
+    monkeypatch.setattr(runner.crisis_service, "guard", lambda action: True)
+    monkeypatch.setattr(runner.selector, "decide_next_action", fake_decide)
+    monkeypatch.setattr(runner.generator, "make_reply", fake_make_reply)
+    monkeypatch.setattr(runner, "multiplexer", types.SimpleNamespace(publish=fake_publish))
+    monkeypatch.setattr(runner, "x_client", FakeXClient())
+    runner.config.LIVE = True
+
+    await runner.reply_mentions_job()
+
+    runner.config.LIVE = previous_live
+
+    # The reflex fires before generation: no draft, no publish, no tweet.
+    assert generated == []
+    assert published == []
+    with get_db_session() as session:
+        assert session.query(Tweet).count() == 0


### PR DESCRIPTION
## Summary

Phase 1 of the approved control-spine plan: before the agent gets more senses and autonomy, it gets a trusted human command line and a hard reflex layer.

### Operator approval line (`services/operator_line.py`)
- New `ApprovalRequest` + `SelfSignal` models (mirroring the `DiscoveryProposal`/`GoalProposal` pattern).
- The agent prompts the operator **only when judgment is required** — via Twilio SMS when `TWILIO_*`/`OPERATOR_PHONE` secrets are set, and always via the dashboard inbox (`GET /api/operator/requests`).
- One command parser for both transports: `YES [id]`, `NO [id]`, `EDIT [id] <text>`, `WHY [id]`, `HOLD [id]`, `FREEZE`, `NEWS`, `INTERVIEW`, `OPINION: <thought>`.
- Load-bearing rules: **YES approves exactly one request** (id-bound; a bare YES refuses when more than one is pending — ambiguity approves nothing) and never enables standing autonomy; **FREEZE disarms outbound action immediately** via the existing `KillSwitch`; **OPINION becomes a `SelfSignal`** the agent weighs, never doctrine.
- Inbound SMS webhook (`POST /api/operator/sms`) validates the Twilio HMAC-SHA1 signature and that the sender is the configured operator phone **before** any text reaches the command parser; dashboard commands (`POST /api/operator/command`) require the admin JWT.
- Every prompt and command is ledgered (`operator_prompted` / `operator_command`).

### Instinct Engine + Identity Gate (`services/instinct.py`)
- **Pre-generation reflex** on every opportunity: scores identity/mission fit, business leverage, relationship value, credibility risk, ragebait risk, evidence need → `engage` / `ignore` / `save_for_later` / `research_first` / `human_review` / `block` / `dm_instead` / `create_asset`. Ragebait and insults are blocked before a single token is generated; hostile relationship history moves the exchange to DM; high stakes files an operator approval.
- **Post-generation gate** on every draft: scores belief/voice/mission fit, credibility risk, drift risk → `allow` / `rewrite` (one regeneration attempt) / `block` / `needs_human` (files an `ApprovalRequest`). Unsourced strong claims stop here.
- Deterministic heuristics (persona + constitution derived) so the layer works offline; every verdict ledgered (`instinct_verdict` / `identity_gate`).
- Wired into `post_proposal_job` and `reply_mentions_job`; the Identity Gate runs before the existing thought-DSL/ethics gate so the final gate always sees the final content. Both layers only narrow what the existing publish gates may see — they never publish.

## Testing
- `python -m pytest`: **198 passed** (26 new: operator command semantics incl. YES-binds-one/ambiguity-refuses/FREEZE-disarms/OPINION-is-signal, Twilio signature validation, instinct verdicts, identity-gate outcomes, and an end-to-end job test proving a ragebait mention never reaches generation or publish).
- `npm run check`: clean. App boot verified; new endpoints registered.
- Docs: `docs/SAFETY_AND_ROLLOUT.md` new sections + ledger events; `.env.example` Twilio block; `replit.md` capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnM7HbkV5ouKu3WST9v7fW

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnM7HbkV5ouKu3WST9v7fW)_