### PR TITLE
Report safe-runtime status from /api/health

### DIFF
--- a/app.py
+++ b/app.py
@@ -1128,16 +1128,23 @@ async def handle_redirect(redirect_id: str):
 
 @app.get("/api/health")
 async def health_check():
-    """Health check with the safe-runtime status an operator needs at a
-    glance: is the agent armed, is crisis pause active, is the decision
-    ledger chain intact. Reads only — this endpoint changes nothing."""
+    """Unauthenticated liveness probe. Deliberately minimal: a public
+    health endpoint must never become a confirmation oracle for arming
+    state, crisis posture, or successful ledger tampering."""
+    return {"ok": True, "timestamp": datetime.now(UTC).isoformat()}
+
+
+@app.get("/api/health/safety")
+async def health_safety(_: RequestContext = Depends(require_role("admin"))):
+    """Authenticated safe-runtime status: is the agent armed, is crisis
+    pause active, is the decision ledger chain intact. Reads only. If a
+    state can't be read, report the uncertainty rather than a false
+    all-clear."""
     config = get_config()
     try:
         crisis_paused = bool(runner.crisis_service.is_paused())
         crisis_reason = runner.crisis_service.reason
     except Exception:
-        # If crisis state can't be read, report the uncertainty rather
-        # than a false "all clear".
         crisis_paused, crisis_reason = None, "unavailable"
     try:
         ledger_ok, broken_at = get_ledger().verify_chain()

--- a/app.py
+++ b/app.py
@@ -215,7 +215,10 @@ async def request_context_middleware(request: Request, call_next):
     except HTTPException as exc:
         response = JSONResponse(status_code=exc.status_code, content={"detail": exc.detail, "request_id": request_id})
     except Exception as exc:
-        logger.error("Unhandled application error", extra_data={"error": str(exc), "path": request.url.path})
+        logger.error(
+            "Unhandled application error",
+            extra={"extra_data": {"error": str(exc), "path": request.url.path}},
+        )
         response = JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"detail": "Internal server error", "request_id": request_id})
 
     duration = elapsed(start)
@@ -1139,20 +1142,38 @@ async def health_safety(_: RequestContext = Depends(require_role("admin"))):
     """Authenticated safe-runtime status: is the agent armed, is crisis
     pause active, is the decision ledger chain intact. Reads only. If a
     state can't be read, report the uncertainty rather than a false
-    all-clear."""
+    all-clear.
+
+    ``ok`` means only "this endpoint answered". ``safe_to_operate`` is the
+    derived control-plane verdict: true when every safety state is readable
+    and the ledger chain is intact; false when the ledger is broken; null
+    when any state is unknown. Crisis pause does NOT make the system
+    unsafe — a working pause is protection functioning — so it is reported
+    alongside, never folded into the verdict silently."""
     config = get_config()
     try:
         crisis_paused = bool(runner.crisis_service.is_paused())
         crisis_reason = runner.crisis_service.reason
-    except Exception:
+    except Exception as exc:
+        logger.warning(f"health_safety: crisis state unreadable: {exc}")
         crisis_paused, crisis_reason = None, "unavailable"
     try:
         ledger_ok, broken_at = get_ledger().verify_chain()
-    except Exception:
+    except Exception as exc:
+        logger.warning(f"health_safety: ledger state unreadable: {exc}")
         ledger_ok, broken_at = None, None
+
+    if crisis_paused is None or ledger_ok is None:
+        safe_to_operate = None  # unknown is reported as unknown
+    elif ledger_ok is False:
+        safe_to_operate = False  # untrustworthy control plane
+    else:
+        safe_to_operate = True
+
     return {
         "ok": True,
         "timestamp": datetime.now(UTC).isoformat(),
+        "safe_to_operate": safe_to_operate,
         "live": bool(config.LIVE),
         "crisis_paused": crisis_paused,
         "crisis_reason": crisis_reason,

--- a/app.py
+++ b/app.py
@@ -1128,8 +1128,30 @@ async def handle_redirect(redirect_id: str):
 
 @app.get("/api/health")
 async def health_check():
-    """Health check endpoint"""
-    return {"ok": True, "timestamp": datetime.now(UTC).isoformat()}
+    """Health check with the safe-runtime status an operator needs at a
+    glance: is the agent armed, is crisis pause active, is the decision
+    ledger chain intact. Reads only — this endpoint changes nothing."""
+    config = get_config()
+    try:
+        crisis_paused = bool(runner.crisis_service.is_paused())
+        crisis_reason = runner.crisis_service.reason
+    except Exception:
+        # If crisis state can't be read, report the uncertainty rather
+        # than a false "all clear".
+        crisis_paused, crisis_reason = None, "unavailable"
+    try:
+        ledger_ok, broken_at = get_ledger().verify_chain()
+    except Exception:
+        ledger_ok, broken_at = None, None
+    return {
+        "ok": True,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "live": bool(config.LIVE),
+        "crisis_paused": crisis_paused,
+        "crisis_reason": crisis_reason,
+        "ledger_ok": ledger_ok,
+        "ledger_broken_at": broken_at,
+    }
 
 # Reflection / learned-mind endpoints
 @app.get("/api/reflections")

--- a/services/security.py
+++ b/services/security.py
@@ -74,7 +74,7 @@ def get_request_context(request: Request) -> RequestContext:
     client_ip = _client_ip(request)
 
     if config.ALLOWED_IPS and client_ip not in config.ALLOWED_IPS:
-        logger.warning("Blocked request from disallowed IP", extra_data={"client_ip": client_ip, "path": request.url.path})
+        logger.warning("Blocked request from disallowed IP", extra={"extra_data": {"client_ip": client_ip, "path": request.url.path}})
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="IP not allowed")
 
     auth_header = request.headers.get("authorization")
@@ -95,7 +95,7 @@ def get_request_context(request: Request) -> RequestContext:
             subject = str(claims.get("sub", subject))
             roles = _parse_roles(claims)
         except Exception as exc:
-            logger.warning("JWT validation failed", extra_data={"error": str(exc)})
+            logger.warning("JWT validation failed", extra={"extra_data": {"error": str(exc)}})
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
 
     context = RequestContext(request_id=req_id, subject=subject, roles=roles, client_ip=client_ip)

--- a/tests/test_health_status.py
+++ b/tests/test_health_status.py
@@ -57,6 +57,32 @@ async def test_safety_endpoint_reports_broken_ledger_chain(tmp_path):
         reset_shared_instances()
 
 
+async def test_safety_verdict_tristate(tmp_path):
+    """safe_to_operate: true on intact chain, false on broken chain."""
+    path = tmp_path / "ledger.jsonl"
+    ledger = DecisionLedger(path=str(path))
+    ledger.record("boot", {})
+    set_shared_instances(ledger=ledger)
+    try:
+        import app as app_module
+
+        healthy = await app_module.health_safety()
+        assert healthy["safe_to_operate"] in (True, None)  # None if crisis unreadable
+        if healthy["crisis_paused"] is not None:
+            assert healthy["safe_to_operate"] is True
+
+        lines = path.read_text().splitlines()
+        lines[0] = lines[0].replace("boot", "tampered")
+        path.write_text("\n".join(lines) + "\n")
+        set_shared_instances(ledger=DecisionLedger(path=str(path)))
+        broken = await app_module.health_safety()
+        if broken["crisis_paused"] is not None:
+            assert broken["safe_to_operate"] is False  # never a false all-clear
+        assert broken["ledger_ok"] is False
+    finally:
+        reset_shared_instances()
+
+
 def test_safety_endpoint_requires_admin_role():
     """The safety route must be behind the admin gate, not public."""
     import app as app_module
@@ -66,3 +92,28 @@ def test_safety_endpoint_requires_admin_role():
     # The public probe carries no dependencies; the safety route must.
     assert routes["/api/health/safety"].dependant.dependencies
     assert not routes["/api/health"].dependant.dependencies
+
+
+def test_http_level_auth_enforced(tmp_path):
+    """Over real HTTP: the public probe answers 200 with no safety fields;
+    the safety endpoint refuses unauthenticated callers outright."""
+    from fastapi.testclient import TestClient
+
+    set_shared_instances(ledger=DecisionLedger(path=str(tmp_path / "l.jsonl")))
+    try:
+        import app as app_module
+
+        client = TestClient(app_module.app)
+        public = client.get("/api/health")
+        assert public.status_code == 200
+        assert _SAFETY_FIELDS.isdisjoint(public.json().keys())
+
+        denied = client.get("/api/health/safety")
+        assert denied.status_code in (401, 403)
+
+        bad_token = client.get(
+            "/api/health/safety", headers={"Authorization": "Bearer not-a-jwt"}
+        )
+        assert bad_token.status_code in (401, 403)
+    finally:
+        reset_shared_instances()

--- a/tests/test_health_status.py
+++ b/tests/test_health_status.py
@@ -1,17 +1,34 @@
-"""The health endpoint must answer the operator's first question — is this
-thing safe right now? — not just "is the process up"."""
+"""Health endpoints: the public probe stays minimal (no oracle for arming,
+crisis, or tamper state); the authenticated safety endpoint answers the
+operator's real question — is this thing safe right now?"""
 
 from services.ledger import DecisionLedger, set_shared_instances, reset_shared_instances
 
+_SAFETY_FIELDS = {"live", "crisis_paused", "crisis_reason", "ledger_ok", "ledger_broken_at"}
 
-async def test_health_reports_safe_runtime_status(tmp_path):
+
+async def test_public_health_is_minimal_no_oracle(tmp_path):
+    set_shared_instances(ledger=DecisionLedger(path=str(tmp_path / "l.jsonl")))
+    try:
+        import app as app_module
+
+        response = await app_module.health_check()
+        assert response["ok"] is True
+        assert "timestamp" in response
+        # No arming, crisis, or ledger-tamper state on the public surface.
+        assert _SAFETY_FIELDS.isdisjoint(response.keys())
+    finally:
+        reset_shared_instances()
+
+
+async def test_safety_endpoint_reports_safe_runtime_status(tmp_path):
     ledger = DecisionLedger(path=str(tmp_path / "ledger.jsonl"))
     ledger.record("boot", {})
     set_shared_instances(ledger=ledger)
     try:
         import app as app_module
 
-        response = await app_module.health_check()
+        response = await app_module.health_safety()
         assert response["ok"] is True
         assert response["live"] is False  # the safe default, reported honestly
         assert response["crisis_paused"] in (True, False, None)
@@ -21,7 +38,7 @@ async def test_health_reports_safe_runtime_status(tmp_path):
         reset_shared_instances()
 
 
-async def test_health_reports_broken_ledger_chain(tmp_path):
+async def test_safety_endpoint_reports_broken_ledger_chain(tmp_path):
     path = tmp_path / "ledger.jsonl"
     ledger = DecisionLedger(path=str(path))
     ledger.record("boot", {})
@@ -34,7 +51,18 @@ async def test_health_reports_broken_ledger_chain(tmp_path):
     try:
         import app as app_module
 
-        response = await app_module.health_check()
-        assert response["ledger_ok"] is False  # tampering is visible, not hidden
+        response = await app_module.health_safety()
+        assert response["ledger_ok"] is False  # tampering visible to the admin
     finally:
         reset_shared_instances()
+
+
+def test_safety_endpoint_requires_admin_role():
+    """The safety route must be behind the admin gate, not public."""
+    import app as app_module
+
+    routes = {r.path: r for r in app_module.app.routes if hasattr(r, "path")}
+    assert "/api/health/safety" in routes
+    # The public probe carries no dependencies; the safety route must.
+    assert routes["/api/health/safety"].dependant.dependencies
+    assert not routes["/api/health"].dependant.dependencies

--- a/tests/test_health_status.py
+++ b/tests/test_health_status.py
@@ -1,0 +1,40 @@
+"""The health endpoint must answer the operator's first question — is this
+thing safe right now? — not just "is the process up"."""
+
+from services.ledger import DecisionLedger, set_shared_instances, reset_shared_instances
+
+
+async def test_health_reports_safe_runtime_status(tmp_path):
+    ledger = DecisionLedger(path=str(tmp_path / "ledger.jsonl"))
+    ledger.record("boot", {})
+    set_shared_instances(ledger=ledger)
+    try:
+        import app as app_module
+
+        response = await app_module.health_check()
+        assert response["ok"] is True
+        assert response["live"] is False  # the safe default, reported honestly
+        assert response["crisis_paused"] in (True, False, None)
+        assert response["ledger_ok"] is True
+        assert response["ledger_broken_at"] is None
+    finally:
+        reset_shared_instances()
+
+
+async def test_health_reports_broken_ledger_chain(tmp_path):
+    path = tmp_path / "ledger.jsonl"
+    ledger = DecisionLedger(path=str(path))
+    ledger.record("boot", {})
+    ledger.record("second", {})
+    # Corrupt the chain: tamper with the first entry on disk.
+    lines = path.read_text().splitlines()
+    lines[0] = lines[0].replace("boot", "tampered")
+    path.write_text("\n".join(lines) + "\n")
+    set_shared_instances(ledger=DecisionLedger(path=str(path)))
+    try:
+        import app as app_module
+
+        response = await app_module.health_check()
+        assert response["ledger_ok"] is False  # tampering is visible, not hidden
+    finally:
+        reset_shared_instances()


### PR DESCRIPTION
## Summary

Runtime health reporting, hardened per review. `/api/health` is a **minimal unauthenticated liveness probe** (`ok`, `timestamp` only — no arming, crisis, or ledger-tamper state on the public surface, so the endpoint cannot become a confirmation oracle). Operational truth lives at **`/api/health/safety`**, behind the admin role:

- `safe_to_operate` tri-state verdict: `true` when all safety states are readable and the ledger chain is intact; `false` when the chain is broken; `null` when any state is unknown. `ok` means only "endpoint answered".
- `live` (armed state, `false` by default), `crisis_paused` + `crisis_reason` (reported alongside the verdict — a working pause is protection functioning, not unsafety), `ledger_ok` + `ledger_broken_at`.
- Unreadable states are logged (diagnosable) and reported as unknown — never a false all-clear.

## Latent defect found and fixed

The new HTTP-level test exposed a real production bug: `services/security.py` and the app middleware passed `extra_data=` as a kwarg to stdlib loggers, raising `TypeError` on every auth failure — meaning **every unauthenticated request to any admin endpoint returned 500 instead of 401/403 over HTTP**. Fixed to the `extra={"extra_data": ...}` contract the JSONFormatter expects.

## Testing

6 tests in `tests/test_health_status.py`: public probe minimal (no safety fields), safety status + tampered-chain visibility, tri-state verdict on intact vs broken chain, admin-gate dependency present, and **HTTP-level 401/403 enforcement** (unauthenticated and bad-token callers). Full suite: **258 passed**; tsc clean.

## Rollback

Revert this PR; additive endpoints, no migrations. The `security.py` logging fix should be preserved in any rollback — it is independent of the health endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjuRe9SzeRJf5RMnPFzeRB