### PR TITLE
Stage 2: CapabilityGrant authority + approval-queue hygiene

### DIFF
--- a/app.py
+++ b/app.py
@@ -725,17 +725,38 @@ async def decide_goal_proposal(
 
 @app.get("/api/operator/requests")
 async def list_operator_requests(status_filter: str = "pending", _: RequestContext = Depends(get_request_context)):
-    """The operator's approval inbox (dashboard fallback for SMS)."""
+    """The operator's approval inbox: ranked (P1 first, then oldest),
+    capped so founder attention is a protected resource, expiring so
+    silence never becomes consent. Overflow is batched, never approved."""
     try:
+        max_active = int(os.getenv("MAX_ACTIVE_APPROVALS", "10"))
         with get_db_session() as session:
+            get_operator_line().sweep_expired(session)
             requests = (
                 session.query(ApprovalRequest)
                 .filter(lambda r: r.status == status_filter)
-                .order_by(lambda r: r.created_at, descending=True)
                 .all()
             )
+            # Rank: urgent first, then oldest waiting.
+            requests.sort(key=lambda r: (r.priority != "P1", r.created_at))
+            active = requests[:max_active] if status_filter == "pending" else requests
+            batched = len(requests) - len(active)
+
+            # Approval-fatigue metric: median decision latency (seconds).
+            decided = [
+                r for r in session.query(ApprovalRequest).all()
+                if r.decided_at is not None and r.decided_via != "expiry"
+            ]
+            latencies = sorted(
+                (r.decided_at - r.created_at).total_seconds() for r in decided
+            )
+            median_latency = latencies[len(latencies) // 2] if latencies else None
+
             return {
-                "count": len(requests),
+                "count": len(active),
+                "batched_count": batched,
+                "max_active": max_active,
+                "median_decision_latency_seconds": median_latency,
                 "requests": [
                     {
                         "id": r.id,
@@ -744,11 +765,13 @@ async def list_operator_requests(status_filter: str = "pending", _: RequestConte
                         "priority": r.priority,
                         "summary": r.summary,
                         "rationale": r.rationale,
+                        "strongest_objection": r.strongest_objection,
                         "payload": r.payload,
                         "status": r.status,
                         "created_at": r.created_at.isoformat(),
+                        "expires_at": r.expires_at.isoformat() if r.expires_at else None,
                     }
-                    for r in requests
+                    for r in active
                 ],
             }
     except Exception as e:
@@ -1039,6 +1062,113 @@ async def list_assessments(_: RequestContext = Depends(get_request_context)):
         from services.venture_protocol import assessment_to_wire
         return {"count": len(assessments),
                 "assessments": [assessment_to_wire(a) for a in assessments]}
+
+
+class CapabilityGrantRequest(BaseModel):
+    approval_request_id: str
+    action_type: str
+    exact_action: str
+    resource: str
+    account_lane_id: str = ""
+    named_targets: List[str] = []
+    max_cost: float = 0.0
+    maximum_uses: int = 1
+    ttl_hours: Optional[int] = None
+    evidence_refs: List[str] = []
+    rollback_note: str = ""
+    trace_id: str = ""
+
+class GrantRevokeRequest(BaseModel):
+    reason: str = ""
+
+
+def _grant_to_dict(g: CapabilityGrant) -> Dict[str, Any]:
+    return {
+        "id": g.id, "approval_request_id": g.approval_request_id,
+        "requester_identity": g.requester_identity,
+        "approver_identity": g.approver_identity,
+        "action_type": g.action_type, "exact_action": g.exact_action,
+        "resource": g.resource, "account_lane_id": g.account_lane_id,
+        "named_targets": g.named_targets, "max_cost": g.max_cost,
+        "currency": g.currency, "maximum_uses": g.maximum_uses,
+        "uses_consumed": g.uses_consumed,
+        "issued_at": g.issued_at.isoformat(),
+        "expires_at": g.expires_at.isoformat() if g.expires_at else None,
+        "risk_tier": g.risk_tier, "rollback_note": g.rollback_note,
+        "revocation_status": g.revocation_status,
+        "revoked_at": g.revoked_at.isoformat() if g.revoked_at else None,
+        "revocation_reason": g.revocation_reason,
+        "trace_id": g.trace_id,
+    }
+
+
+@app.post("/api/capability-grants")
+async def create_capability_grant(
+    request: CapabilityGrantRequest,
+    _: RequestContext = Depends(require_role("admin")),
+):
+    """Mint a single-purpose, expiring capability from an APPROVED request.
+    Grants never widen standing autonomy: exact action, exact resource,
+    bounded uses, bounded window. Everything is ledgered."""
+    from services.capability import CapabilityError, get_capability_service
+    try:
+        with get_db_session() as session:
+            grant = get_capability_service().mint_from_approval(
+                session,
+                request.approval_request_id,
+                request.action_type,
+                request.exact_action,
+                request.resource,
+                account_lane_id=request.account_lane_id,
+                named_targets=request.named_targets,
+                max_cost=request.max_cost,
+                maximum_uses=request.maximum_uses,
+                ttl_hours=request.ttl_hours,
+                evidence_refs=request.evidence_refs,
+                rollback_note=request.rollback_note,
+                trace_id=request.trace_id,
+            )
+        return {"success": True, "grant": _grant_to_dict(grant)}
+    except CapabilityError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+
+@app.get("/api/capability-grants")
+async def list_capability_grants(_: RequestContext = Depends(get_request_context)):
+    with get_db_session() as session:
+        grants = (
+            session.query(CapabilityGrant)
+            .order_by(lambda g: g.issued_at, descending=True)
+            .all()
+        )
+        return {"count": len(grants), "grants": [_grant_to_dict(g) for g in grants]}
+
+
+@app.get("/api/capability-grants/{grant_id}")
+async def get_capability_grant(grant_id: str, _: RequestContext = Depends(get_request_context)):
+    with get_db_session() as session:
+        grant = session.query(CapabilityGrant).filter(lambda g: g.id == grant_id).first()
+        if grant is None:
+            raise HTTPException(status_code=404, detail="Grant not found")
+        return _grant_to_dict(grant)
+
+
+@app.post("/api/capability-grants/{grant_id}/revoke")
+async def revoke_capability_grant(
+    grant_id: str,
+    request: GrantRevokeRequest,
+    _: RequestContext = Depends(require_role("admin")),
+):
+    """Revocation is immediate. Revoked grants fail closed at execution."""
+    from services.capability import CapabilityError, get_capability_service
+    try:
+        with get_db_session() as session:
+            grant = get_capability_service().revoke(
+                session, grant_id, reason=request.reason,
+            )
+        return {"success": True, "grant": _grant_to_dict(grant)}
+    except CapabilityError as e:
+        raise HTTPException(status_code=404, detail=str(e))
 
 
 @app.post("/api/validation-results")

--- a/db/models.py
+++ b/db/models.py
@@ -283,10 +283,51 @@ class ApprovalRequest:
     summary: str = ""
     payload: Dict[str, Any] = field(default_factory=dict)
     rationale: str = ""
+    strongest_objection: str = ""  # the best argument against approving
     status: str = "pending"  # pending | approved | rejected | edited | held | expired
     created_at: datetime = field(default_factory=_utcnow)
+    expires_at: Optional[datetime] = None  # stale requests close automatically
     decided_at: Optional[datetime] = None
     decided_via: Optional[str] = None  # "sms" | "dashboard"
+
+
+@dataclass
+class CapabilityGrant:
+    """The executable authorization artifact: a single-purpose, exactly
+    scoped, expiring, revocable permission minted from a human approval.
+    Approval never widens standing autonomy — a grant authorizes one exact
+    action against one exact resource, a bounded number of times, for a
+    bounded window. Everything about its lifecycle is ledgered."""
+
+    id: str = field(default_factory=_uuid)
+    requester_identity: str = ""  # organ/service that asked
+    approver_identity: str = ""  # human actor who said yes
+    approval_request_id: str = ""  # the ApprovalRequest it was minted from
+    action_type: str = ""  # e.g. "publish_post" | "send_dm" | "run_validation"
+    exact_action: str = ""  # human-readable exact act authorized
+    resource: str = ""  # exact resource id (draft id, packet id, lane id...)
+    account_lane_id: str = ""
+    named_targets: List[str] = field(default_factory=list)
+    max_cost: float = 0.0
+    currency: str = "USD"
+    max_frequency: str = ""  # e.g. "1/day"; informational bound
+    maximum_uses: int = 1
+    uses_consumed: int = 0
+    issued_at: datetime = field(default_factory=_utcnow)
+    not_before: Optional[datetime] = None
+    expires_at: Optional[datetime] = None
+    evidence_refs: List[str] = field(default_factory=list)
+    policy_version: str = ""
+    constitution_hash: str = ""
+    risk_tier: str = "tier4"  # consequential by default
+    rollback_note: str = ""
+    revocation_status: str = "active"  # active | revoked
+    revoked_at: Optional[datetime] = None
+    revoked_by: str = ""
+    revocation_reason: str = ""
+    idempotency_key: str = field(default_factory=_uuid)
+    trace_id: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -487,6 +528,7 @@ __all__ = [
     "DiscoveryProposal",
     "GoalProposal",
     "ApprovalRequest",
+    "CapabilityGrant",
     "SelfSignal",
     "ContextPacket",
     "Idea",

--- a/services/capability.py
+++ b/services/capability.py
@@ -130,6 +130,23 @@ class CapabilityService:
             self._reject(grant_id, "ledger_chain_broken")
             raise CapabilityError("decision ledger chain is broken — failing closed")
 
+        # Human approval is necessary but not sufficient: crisis pause
+        # suspends consequential execution even for validly granted acts,
+        # and an unreadable crisis state fails closed, not open.
+        try:
+            import runner
+            crisis_paused = bool(runner.crisis_service.is_paused())
+        except Exception:
+            crisis_paused = None
+        if crisis_paused is not False:
+            reason = "crisis_paused" if crisis_paused else "crisis_state_unreadable"
+            self._reject(grant_id, reason)
+            raise CapabilityError(
+                "crisis pause active — consequential execution is suspended"
+                if crisis_paused else
+                "crisis state unreadable — failing closed"
+            )
+
         grant = session.query(CapabilityGrant).filter(lambda g: g.id == grant_id).first()
         if grant is None:
             self._reject(grant_id, "unknown_grant")

--- a/services/capability.py
+++ b/services/capability.py
@@ -1,0 +1,218 @@
+"""Capability-based authority: narrow, expiring, revocable permissions.
+
+A CapabilityGrant is minted only from an approved ApprovalRequest and
+authorizes one exact action against one exact resource, a bounded number
+of times, inside a bounded window. Validation happens at execution time,
+not only at approval time; expired, revoked, mismatched, exhausted, or
+replayed grants fail closed, and a broken decision-ledger chain disarms
+consumption entirely. Every lifecycle event is ledgered.
+
+This module authorizes nothing by itself — it verifies that a human did.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, UTC
+from typing import Any, Dict, List, Optional
+
+from db.models import ApprovalRequest, CapabilityGrant
+from services.ledger import DecisionLedger, get_ledger
+from services.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class CapabilityError(PermissionError):
+    """A grant failed validation. Execution must not proceed."""
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def default_ttl_hours() -> int:
+    try:
+        return int(os.getenv("CAPABILITY_TTL_HOURS", "72"))
+    except ValueError:
+        return 72
+
+
+class CapabilityService:
+    def __init__(self, ledger: Optional[DecisionLedger] = None) -> None:
+        self._ledger = ledger
+
+    @property
+    def ledger(self) -> DecisionLedger:
+        return self._ledger or get_ledger()
+
+    # ------------------------------------------------------------------ #
+    # Minting: only from a human-approved request
+    # ------------------------------------------------------------------ #
+    def mint_from_approval(
+        self,
+        session: Any,
+        approval_request_id: str,
+        action_type: str,
+        exact_action: str,
+        resource: str,
+        *,
+        approver_identity: str = "admin",
+        requester_identity: str = "daleobanks",
+        account_lane_id: str = "",
+        named_targets: Optional[List[str]] = None,
+        max_cost: float = 0.0,
+        maximum_uses: int = 1,
+        ttl_hours: Optional[int] = None,
+        evidence_refs: Optional[List[str]] = None,
+        rollback_note: str = "",
+        trace_id: str = "",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> CapabilityGrant:
+        approval = session.query(ApprovalRequest).filter(
+            lambda a: a.id == approval_request_id
+        ).first()
+        if approval is None:
+            raise CapabilityError("unknown approval request")
+        if approval.status != "approved":
+            raise CapabilityError(
+                f"approval request is '{approval.status}' — grants mint only from approvals"
+            )
+        if not action_type or not resource:
+            raise CapabilityError("action_type and resource are required")
+
+        grant = CapabilityGrant(
+            requester_identity=requester_identity,
+            approver_identity=approver_identity,
+            approval_request_id=approval_request_id,
+            action_type=action_type,
+            exact_action=exact_action,
+            resource=resource,
+            account_lane_id=account_lane_id,
+            named_targets=list(named_targets or []),
+            max_cost=float(max_cost),
+            maximum_uses=int(maximum_uses),
+            expires_at=_now() + timedelta(hours=ttl_hours or default_ttl_hours()),
+            evidence_refs=list(evidence_refs or []),
+            rollback_note=rollback_note,
+            trace_id=trace_id,
+            metadata=metadata or {},
+        )
+        session.add(grant)
+        session.commit()
+        self.ledger.record("capability_granted", {
+            "id": grant.id, "approval_request_id": approval_request_id,
+            "action_type": action_type, "resource": resource,
+            "maximum_uses": grant.maximum_uses,
+            "expires_at": grant.expires_at.isoformat(),
+        })
+        return grant
+
+    # ------------------------------------------------------------------ #
+    # Execution-time validation: the load-bearing gate
+    # ------------------------------------------------------------------ #
+    def validate_and_consume(
+        self,
+        session: Any,
+        grant_id: str,
+        action_type: str,
+        resource: str,
+        *,
+        target: Optional[str] = None,
+        cost: float = 0.0,
+    ) -> CapabilityGrant:
+        """Validate a grant immediately before execution and consume one
+        use. Any failure raises CapabilityError — the caller must not act."""
+        # A broken ledger disarms external action entirely: if the record
+        # of authority can't be trusted, no authority is exercised.
+        chain_ok, _ = self.ledger.verify_chain()
+        if not chain_ok:
+            self._reject(grant_id, "ledger_chain_broken")
+            raise CapabilityError("decision ledger chain is broken — failing closed")
+
+        grant = session.query(CapabilityGrant).filter(lambda g: g.id == grant_id).first()
+        if grant is None:
+            self._reject(grant_id, "unknown_grant")
+            raise CapabilityError("unknown capability grant")
+        if grant.revocation_status != "active":
+            self._reject(grant_id, "revoked")
+            raise CapabilityError("grant is revoked")
+        now = _now()
+        if grant.not_before and now < grant.not_before:
+            self._reject(grant_id, "not_yet_valid")
+            raise CapabilityError("grant is not yet valid")
+        if grant.expires_at and now >= grant.expires_at:
+            self._reject(grant_id, "expired")
+            self.ledger.record("capability_expired", {"id": grant.id})
+            raise CapabilityError("grant is expired")
+        if grant.uses_consumed >= grant.maximum_uses:
+            self._reject(grant_id, "exhausted")
+            raise CapabilityError("grant is exhausted — replay refused")
+        if grant.action_type != action_type:
+            self._reject(grant_id, "action_mismatch")
+            raise CapabilityError(
+                f"grant authorizes '{grant.action_type}', not '{action_type}'"
+            )
+        if grant.resource != resource:
+            self._reject(grant_id, "resource_mismatch")
+            raise CapabilityError("grant does not cover this resource")
+        if target is not None and grant.named_targets and target not in grant.named_targets:
+            self._reject(grant_id, "target_mismatch")
+            raise CapabilityError("grant does not cover this target")
+        if cost and cost > grant.max_cost:
+            self._reject(grant_id, "cost_exceeded")
+            raise CapabilityError(
+                f"cost {cost} exceeds the grant ceiling {grant.max_cost}"
+            )
+
+        grant.uses_consumed += 1
+        session.commit()
+        self.ledger.record("capability_consumed", {
+            "id": grant.id, "action_type": action_type, "resource": resource,
+            "use": grant.uses_consumed, "of": grant.maximum_uses,
+        })
+        return grant
+
+    def _reject(self, grant_id: str, reason: str) -> None:
+        self.ledger.record("capability_rejected", {"id": grant_id, "reason": reason})
+        logger.warning(f"Capability rejected: {grant_id} ({reason})")
+
+    # ------------------------------------------------------------------ #
+    # Revocation: immediate, ledgered
+    # ------------------------------------------------------------------ #
+    def revoke(
+        self, session: Any, grant_id: str, *, revoked_by: str = "admin", reason: str = ""
+    ) -> CapabilityGrant:
+        grant = session.query(CapabilityGrant).filter(lambda g: g.id == grant_id).first()
+        if grant is None:
+            raise CapabilityError("unknown capability grant")
+        grant.revocation_status = "revoked"
+        grant.revoked_at = _now()
+        grant.revoked_by = revoked_by
+        grant.revocation_reason = reason
+        session.commit()
+        self.ledger.record("capability_revoked", {
+            "id": grant.id, "by": revoked_by, "reason": reason,
+        })
+        return grant
+
+
+_SHARED: Optional[CapabilityService] = None
+
+
+def get_capability_service() -> CapabilityService:
+    global _SHARED
+    if _SHARED is None:
+        _SHARED = CapabilityService()
+    return _SHARED
+
+
+def set_capability_service(service: Optional[CapabilityService]) -> None:
+    global _SHARED
+    _SHARED = service
+
+
+__all__ = [
+    "CapabilityError", "CapabilityService",
+    "get_capability_service", "set_capability_service", "default_ttl_hours",
+]

--- a/services/operator_line.py
+++ b/services/operator_line.py
@@ -83,12 +83,33 @@ class OperatorLine:
         payload: Optional[Dict[str, Any]] = None,
         rationale: str = "",
         priority: str = "P2",
+        strongest_objection: str = "",
+        ttl_hours: Optional[int] = None,
     ) -> ApprovalRequest:
         """File an ApprovalRequest and prompt the operator (SMS if configured,
-        dashboard inbox always)."""
+        dashboard inbox always). Duplicate pending requests (same kind and
+        payload) collapse into the existing one — the queue must never
+        manufacture approval demand. Requests expire; silence is never
+        consent, and an expired request simply closes."""
+        payload = payload or {}
+        if payload:  # only a non-empty payload identifies the same act
+            for existing in session.query(ApprovalRequest).all():
+                if (existing.status == "pending" and existing.kind == kind
+                        and existing.payload == payload):
+                    return existing
+
+        import os as _os
+        from datetime import timedelta as _td
+        try:
+            ttl = int(ttl_hours if ttl_hours is not None
+                      else _os.getenv("APPROVAL_TTL_HOURS", "72"))
+        except ValueError:
+            ttl = 72
         request = ApprovalRequest(
-            kind=kind, summary=summary, payload=payload or {},
+            kind=kind, summary=summary, payload=payload,
             rationale=rationale, priority=priority,
+            strongest_objection=strongest_objection,
+            expires_at=datetime.now(UTC) + _td(hours=ttl),
         )
         session.add(request)
         session.commit()
@@ -109,10 +130,31 @@ class OperatorLine:
         })
         return request
 
+    def sweep_expired(self, session: Any) -> int:
+        """Close pending requests past their expiry. Queue overflow and
+        operator silence must never become implicit approval — an expired
+        request is simply closed, ledgered, and gone."""
+        expired = 0
+        now = datetime.now(UTC)
+        for request in session.query(ApprovalRequest).all():
+            if (request.status == "pending" and request.expires_at
+                    and now >= request.expires_at):
+                request.status = "expired"
+                request.decided_at = now
+                request.decided_via = "expiry"
+                expired += 1
+                self.ledger.record("approval_expired", {
+                    "id": request.id, "code": request.code, "kind": request.kind,
+                })
+        if expired:
+            session.commit()
+        return expired
+
     # ------------------------------------------------------------------ #
     # Inbound: executing operator commands
     # ------------------------------------------------------------------ #
     def handle_command(self, session: Any, text: str, via: str = "dashboard") -> Dict[str, Any]:
+        self.sweep_expired(session)
         raw = (text or "").strip()
         if not raw:
             return self._done("HELP", via, ok=False, reply=HELP_TEXT)

--- a/tests/test_approval_queue.py
+++ b/tests/test_approval_queue.py
@@ -1,0 +1,113 @@
+"""Approval queue hygiene: ranked, capped, expiring, deduplicated.
+Founder attention is a protected resource; queue overflow and operator
+silence never become implicit approval."""
+
+from datetime import datetime, timedelta, UTC
+
+from db.models import ApprovalRequest
+from db.session import get_db_session, init_db
+from services.ledger import DecisionLedger, KillSwitch, set_shared_instances, reset_shared_instances
+from services.operator_line import OperatorLine
+
+
+def _setup(tmp_path):
+    init_db()
+    ledger = DecisionLedger(path=str(tmp_path / "l.jsonl"))
+    set_shared_instances(ledger=ledger)
+    line = OperatorLine(ledger=ledger, kill_switch=KillSwitch(ledger=ledger))
+    return ledger, line
+
+
+def test_requests_expire_and_cannot_be_approved(tmp_path):
+    ledger, line = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            request = line.request_approval(
+                session, kind="publish", summary="stale ask",
+                payload={"draft_id": "d1"}, ttl_hours=1,
+            )
+            request.expires_at = datetime.now(UTC) - timedelta(minutes=1)
+            session.commit()
+
+            # Any command sweeps first; the stale request closes.
+            result = line.handle_command(session, f"YES {request.code}")
+            assert result["ok"] is False  # nothing pending to approve
+
+            stored = session.query(ApprovalRequest).filter(
+                lambda r: r.id == request.id
+            ).first()
+        assert stored.status == "expired"
+        assert stored.decided_via == "expiry"
+        assert ledger.replay("approval_expired")
+    finally:
+        reset_shared_instances()
+
+
+def test_duplicate_pending_requests_collapse(tmp_path):
+    ledger, line = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            first = line.request_approval(
+                session, kind="publish", summary="post the thread",
+                payload={"draft_id": "d1"},
+            )
+            second = line.request_approval(
+                session, kind="publish", summary="post the thread (again)",
+                payload={"draft_id": "d1"},
+            )
+            assert second.id == first.id  # collapsed, not duplicated
+            pending = [r for r in session.query(ApprovalRequest).all()
+                       if r.status == "pending"]
+        assert len(pending) == 1
+    finally:
+        reset_shared_instances()
+
+
+async def test_queue_is_ranked_and_capped_and_overflow_batches(tmp_path, monkeypatch):
+    monkeypatch.setenv("MAX_ACTIVE_APPROVALS", "3")
+    ledger, line = _setup(tmp_path)
+    try:
+        import app as app_module
+
+        with get_db_session() as session:
+            for i in range(5):
+                line.request_approval(
+                    session, kind="publish", summary=f"ask {i}",
+                    payload={"draft_id": f"d{i}"},
+                )
+            urgent = line.request_approval(
+                session, kind="crisis_action", summary="urgent ask",
+                payload={"draft_id": "urgent"}, priority="P1",
+            )
+
+        response = await app_module.list_operator_requests()
+        assert response["count"] == 3  # capped
+        assert response["batched_count"] == 3  # overflow batched, visible
+        assert response["requests"][0]["id"] == urgent.id  # P1 ranks first
+        assert response["requests"][0]["expires_at"] is not None
+
+        # Batched overflow is still pending — never implicitly approved.
+        with get_db_session() as session:
+            pending = [r for r in session.query(ApprovalRequest).all()
+                       if r.status == "pending"]
+        assert len(pending) == 6
+        assert all(r.status == "pending" for r in pending)
+    finally:
+        reset_shared_instances()
+
+
+async def test_strongest_objection_travels_to_the_operator(tmp_path):
+    ledger, line = _setup(tmp_path)
+    try:
+        import app as app_module
+
+        with get_db_session() as session:
+            line.request_approval(
+                session, kind="publish", summary="post with risk",
+                payload={"draft_id": "d9"},
+                strongest_objection="Could read as financial advice without disclosure",
+            )
+        response = await app_module.list_operator_requests()
+        assert response["requests"][0]["strongest_objection"].startswith("Could read")
+    finally:
+        reset_shared_instances()

--- a/tests/test_capability_grants.py
+++ b/tests/test_capability_grants.py
@@ -1,0 +1,164 @@
+"""CapabilityGrant: authority as narrow, expiring, revocable capabilities.
+Grants mint only from human approvals; validation happens at execution
+time; expired, revoked, mismatched, exhausted, replayed, or over-budget
+grants fail closed; a broken ledger disarms consumption entirely."""
+
+from datetime import datetime, timedelta, UTC
+
+import pytest
+
+from db.models import ApprovalRequest, CapabilityGrant
+from db.session import get_db_session, init_db
+from services.capability import CapabilityError, CapabilityService
+from services.ledger import DecisionLedger, KillSwitch, set_shared_instances, reset_shared_instances
+from services.operator_line import OperatorLine
+
+
+def _setup(tmp_path):
+    init_db()
+    ledger = DecisionLedger(path=str(tmp_path / "l.jsonl"))
+    set_shared_instances(ledger=ledger)
+    service = CapabilityService(ledger=ledger)
+    line = OperatorLine(ledger=ledger, kill_switch=KillSwitch(ledger=ledger))
+    return ledger, service, line
+
+
+def _approved_request(session, line):
+    request = line.request_approval(
+        session, kind="publish", summary="Publish one educational post",
+        payload={"draft_id": "draft-1"},
+        strongest_objection="Audience may read it as advice; disclosure required",
+    )
+    line.handle_command(session, f"YES {request.code}")
+    return request
+
+
+def test_grant_mints_only_from_approved_requests(tmp_path):
+    ledger, service, line = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            pending = line.request_approval(
+                session, kind="publish", summary="Not yet approved",
+                payload={"draft_id": "draft-x"},
+            )
+            with pytest.raises(CapabilityError):
+                service.mint_from_approval(
+                    session, pending.id, "publish_post", "publish draft-x", "draft-x",
+                )
+            approved = _approved_request(session, line)
+            grant = service.mint_from_approval(
+                session, approved.id, "publish_post", "publish draft-1", "draft-1",
+            )
+        assert grant.maximum_uses == 1
+        assert grant.expires_at is not None
+        assert ledger.replay("capability_granted")
+    finally:
+        reset_shared_instances()
+
+
+def test_valid_one_time_grant_succeeds_then_replay_fails(tmp_path):
+    ledger, service, line = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            approved = _approved_request(session, line)
+            grant = service.mint_from_approval(
+                session, approved.id, "publish_post", "publish draft-1", "draft-1",
+            )
+            # Mocked execution: validate-and-consume, no external action.
+            consumed = service.validate_and_consume(
+                session, grant.id, "publish_post", "draft-1",
+            )
+            assert consumed.uses_consumed == 1
+            # Replay: the same grant a second time fails closed.
+            with pytest.raises(CapabilityError):
+                service.validate_and_consume(session, grant.id, "publish_post", "draft-1")
+        assert ledger.replay("capability_consumed")
+        assert any(e["payload"]["reason"] == "exhausted"
+                   for e in ledger.replay("capability_rejected"))
+    finally:
+        reset_shared_instances()
+
+
+def test_expired_revoked_and_mismatched_grants_fail_closed(tmp_path):
+    ledger, service, line = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            approved = _approved_request(session, line)
+
+            expired = service.mint_from_approval(
+                session, approved.id, "publish_post", "publish draft-1", "draft-1",
+            )
+            expired.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            with pytest.raises(CapabilityError):
+                service.validate_and_consume(session, expired.id, "publish_post", "draft-1")
+
+            revoked = service.mint_from_approval(
+                session, approved.id, "publish_post", "publish draft-1", "draft-1",
+            )
+            service.revoke(session, revoked.id, reason="operator changed mind")
+            with pytest.raises(CapabilityError):
+                service.validate_and_consume(session, revoked.id, "publish_post", "draft-1")
+
+            wrong = service.mint_from_approval(
+                session, approved.id, "publish_post", "publish draft-1", "draft-1",
+            )
+            with pytest.raises(CapabilityError):  # wrong action
+                service.validate_and_consume(session, wrong.id, "send_dm", "draft-1")
+            with pytest.raises(CapabilityError):  # wrong resource
+                service.validate_and_consume(session, wrong.id, "publish_post", "draft-999")
+
+            budget = service.mint_from_approval(
+                session, approved.id, "spend", "spend on one experiment", "exp-1",
+                max_cost=25.0,
+            )
+            with pytest.raises(CapabilityError):  # over budget
+                service.validate_and_consume(session, budget.id, "spend", "exp-1", cost=26.0)
+        assert ledger.replay("capability_revoked")
+    finally:
+        reset_shared_instances()
+
+
+def test_broken_ledger_disarms_consumption(tmp_path):
+    path = tmp_path / "l.jsonl"
+    ledger, service, line = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            approved = _approved_request(session, line)
+            grant = service.mint_from_approval(
+                session, approved.id, "publish_post", "publish draft-1", "draft-1",
+            )
+        # Tamper with the chain on disk; consumption must fail closed.
+        lines = path.read_text().splitlines()
+        lines[0] = lines[0].replace("operator_prompted", "tampered_event")
+        path.write_text("\n".join(lines) + "\n")
+        broken = CapabilityService(ledger=DecisionLedger(path=str(path)))
+        with get_db_session() as session:
+            with pytest.raises(CapabilityError):
+                broken.validate_and_consume(session, grant.id, "publish_post", "draft-1")
+    finally:
+        reset_shared_instances()
+
+
+def test_grants_never_widen_standing_autonomy(tmp_path):
+    """A grant covers exactly one scope; approval elsewhere grants nothing
+    here, and consuming a grant leaves LIVE untouched."""
+    from config import get_config
+    ledger, service, line = _setup(tmp_path)
+    try:
+        live_before = get_config().LIVE
+        with get_db_session() as session:
+            approved = _approved_request(session, line)
+            grant = service.mint_from_approval(
+                session, approved.id, "publish_post", "publish draft-1", "draft-1",
+                named_targets=["lane-main"],
+            )
+            with pytest.raises(CapabilityError):  # unnamed target refused
+                service.validate_and_consume(
+                    session, grant.id, "publish_post", "draft-1", target="lane-other",
+                )
+            service.validate_and_consume(
+                session, grant.id, "publish_post", "draft-1", target="lane-main",
+            )
+        assert get_config().LIVE == live_before  # consuming never arms
+    finally:
+        reset_shared_instances()

--- a/tests/test_capability_grants.py
+++ b/tests/test_capability_grants.py
@@ -139,6 +139,31 @@ def test_broken_ledger_disarms_consumption(tmp_path):
         reset_shared_instances()
 
 
+def test_crisis_pause_suspends_grant_consumption(tmp_path, monkeypatch):
+    """Human approval is necessary but not sufficient: crisis pause blocks
+    execution of even a validly granted act."""
+    import runner
+
+    ledger, service, line = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            approved = _approved_request(session, line)
+            grant = service.mint_from_approval(
+                session, approved.id, "publish_post", "publish draft-1", "draft-1",
+            )
+            monkeypatch.setattr(runner.crisis_service, "is_paused", lambda: True)
+            with pytest.raises(CapabilityError):
+                service.validate_and_consume(session, grant.id, "publish_post", "draft-1")
+            # Grant untouched: it can be used once the crisis clears.
+            assert grant.uses_consumed == 0
+            monkeypatch.setattr(runner.crisis_service, "is_paused", lambda: False)
+            service.validate_and_consume(session, grant.id, "publish_post", "draft-1")
+        assert any(e["payload"]["reason"] == "crisis_paused"
+                   for e in ledger.replay("capability_rejected"))
+    finally:
+        reset_shared_instances()
+
+
 def test_grants_never_widen_standing_autonomy(tmp_path):
     """A grant covers exactly one scope; approval elsewhere grants nothing
     here, and consuming a grant leaves LIVE untouched."""


### PR DESCRIPTION
## Problem

"Human approved" was a status, not an enforceable scope: nothing bound an approval to one exact action, one resource, one use, one window — and the approval queue could grow without rank, cap, or expiry, making approval fatigue part of the de-facto security model.

## Constitutional rationale

Invariants enforced in code: no consequential action without a ledgered, scoped, valid, unexpired grant; approval never widens standing autonomy; a broken ledger chain disarms; queue overflow and operator silence never become implicit approval; founder attention is a protected resource.

## Implementation

- `db/models.py`: `CapabilityGrant` (full mandated field set) + `ApprovalRequest.strongest_objection` / `expires_at`.
- `services/capability.py`: mint **only from approved requests**; execution-time `validate_and_consume` (ledger-chain check first — broken chain fails closed; then revocation/window/uses/action/resource/target/cost checks, each rejection ledgered with its reason); immediate ledgered revocation.
- `services/operator_line.py`: duplicate pending requests (same kind + same non-empty payload) collapse; requests get expiry (`APPROVAL_TTL_HOURS`, default 72h); `sweep_expired` runs before every command so expired asks close (`decided_via: expiry`, ledgered) and can never be approved.
- `app.py`: grant endpoints (create/list/get/revoke, admin-gated writes); `/api/operator/requests` now ranks P1-first-then-oldest, caps active decisions (`MAX_ACTIVE_APPROVALS`, default 10) with overflow batched and visibly counted, surfaces `strongest_objection` and expiry, and reports median decision latency (approval-fatigue metric).

## Threats addressed

Stale-approval replay (one-time consumption + expiry), scope creep (exact action/resource/target/cost match), post-approval regret (revocation before execution), ledger tampering (consumption disarmed), approval fatigue (rank/cap/expiry/latency metric), duplicate approval demand (dedupe).

## Tests

9 new; full suite **275 passed**; tsc clean. One pre-existing test initially regressed (payload-less requests collapsing) — fixed by scoping dedupe to non-empty payloads, behavior documented in code.

## Residual risk / rollback

Grants gate execution paths that call `validate_and_consume`; wiring every future external adapter through it is Stage 6+/8 discipline. Rollback: revert this PR — additive, no migrations.

**Stacked on PR #49. Next: anti-cathedral policy + metric hierarchy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjuRe9SzeRJf5RMnPFzeRB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjuRe9SzeRJf5RMnPFzeRB)_