### PR TITLE
Stage 3: executable anti-cathedral policy + lexicographic metric hierarchy

### DIFF
--- a/app.py
+++ b/app.py
@@ -1064,6 +1064,34 @@ async def list_assessments(_: RequestContext = Depends(get_request_context)):
                 "assessments": [assessment_to_wire(a) for a in assessments]}
 
 
+class WorkCheckRequest(BaseModel):
+    category: str
+    description: str = ""
+
+
+@app.post("/api/policy/work-check")
+async def check_work_policy(
+    request: WorkCheckRequest, _: RequestContext = Depends(get_request_context)
+):
+    """The anti-cathedral rule, executable: may this work proceed given the
+    state of the external-evidence window? Decisions are ledgered."""
+    from services.evidence_policy import evaluate_work
+    with get_db_session() as session:
+        return evaluate_work(session, request.category, description=request.description)
+
+
+@app.get("/api/metrics/institutional")
+async def get_institutional_metrics(
+    base_j: Optional[float] = None, _: RequestContext = Depends(get_request_context)
+):
+    """The numbers the institution grows by: constitutional health,
+    evidence window, loop closure, negative-result retention, founder
+    decision load — and Evidence-Weighted J when a base J is supplied."""
+    from services.evidence_policy import institutional_metrics
+    with get_db_session() as session:
+        return institutional_metrics(session, base_j=base_j)
+
+
 class CapabilityGrantRequest(BaseModel):
     approval_request_id: str
     action_type: str

--- a/services/evidence_policy.py
+++ b/services/evidence_policy.py
@@ -1,0 +1,213 @@
+"""The anti-cathedral rule as executable policy, and the lexicographic
+metric hierarchy that keeps lower-level output from purchasing its way
+past constitutional health.
+
+Anti-cathedral: when the configured external-evidence window is empty —
+no ValidationResults recorded inside EVIDENCE_WINDOW_DAYS — internal
+expansion is denied. Security repair, compliance repair, critical
+reliability repair, and work that directly produces or unblocks external
+evidence remain permitted. The institution must not become a
+sophisticated procrastination machine.
+
+Metric hierarchy (lexicographic — no lower layer buys off a higher one):
+  1. constitutional health   (a breach hard-zeros the period)
+  2. evidence quality        (external reality gates everything below)
+  3. trusted usefulness / 4. adoption / 5. economics / 6. efficiency /
+  7. option value            (reported, never traded upward)
+
+Evidence-Weighted J = goal-aligned J × evidence multiplier × health gate.
+With zero external evidence the multiplier is zero: activity without
+reality-contact is not progress, by construction.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, UTC
+from typing import Any, Dict, Optional
+
+from db.models import ApprovalRequest, ValidationResult
+from services.ledger import DecisionLedger, get_ledger
+
+# Work categories the policy evaluator recognizes. Anything else is denied.
+WORK_CATEGORIES = frozenset({
+    "external_evidence_producing",
+    "unblocks_external_evidence",
+    "security_repair",
+    "compliance_repair",
+    "critical_reliability_repair",
+    "internal_expansion",
+})
+
+# Categories permitted even when the evidence window is empty.
+ALWAYS_PERMITTED = frozenset({
+    "external_evidence_producing",
+    "unblocks_external_evidence",
+    "security_repair",
+    "compliance_repair",
+    "critical_reliability_repair",
+})
+
+# Evidence tiers → weight. Payment outranks everything; passive
+# observation barely counts. Matches ALLOWED_EVIDENCE_TIERS.
+TIER_WEIGHTS = {
+    "payment": 1.0,
+    "commitment": 0.8,
+    "conversation": 0.6,
+    "engagement": 0.4,
+    "observation": 0.2,
+}
+
+# Ledger events that constitute a material constitutional breach.
+BREACH_EVENTS = frozenset({"constitutional_violation"})
+
+
+def window_days() -> int:
+    try:
+        return int(os.getenv("EVIDENCE_WINDOW_DAYS", "14"))
+    except ValueError:
+        return 14
+
+
+def evidence_window(session: Any) -> Dict[str, Any]:
+    """State of the external-evidence window: recorded ValidationResults
+    inside the configured horizon."""
+    horizon = datetime.now(UTC) - timedelta(days=window_days())
+    results = [
+        r for r in session.query(ValidationResult).all()
+        if r.created_at >= horizon
+    ]
+    return {
+        "window_days": window_days(),
+        "validation_results": len(results),
+        "empty": len(results) == 0,
+    }
+
+
+def evaluate_work(
+    session: Any,
+    category: str,
+    *,
+    description: str = "",
+    ledger: Optional[DecisionLedger] = None,
+) -> Dict[str, Any]:
+    """Classify proposed work and decide whether it may proceed under the
+    anti-cathedral rule. Decisions are ledgered — the record of what the
+    institution refused to build is part of its memory."""
+    ledger = ledger or get_ledger()
+    window = evidence_window(session)
+
+    if category not in WORK_CATEGORIES:
+        decision = {"allowed": False, "category": category, "window": window,
+                    "reason": f"unknown work category; allowed: {sorted(WORK_CATEGORIES)}"}
+    elif category in ALWAYS_PERMITTED:
+        decision = {"allowed": True, "category": category, "window": window,
+                    "reason": "permitted regardless of evidence window"}
+    elif window["empty"]:
+        decision = {"allowed": False, "category": category, "window": window,
+                    "reason": (
+                        "external-evidence window is empty: internal expansion is "
+                        "blocked until the institution records contact with reality"
+                    )}
+    else:
+        decision = {"allowed": True, "category": category, "window": window,
+                    "reason": "evidence window is non-empty"}
+
+    ledger.record("anti_cathedral_decision", {
+        "category": category,
+        "allowed": decision["allowed"],
+        "description": (description or "")[:200],
+        "window_results": window["validation_results"],
+    })
+    return decision
+
+
+# --------------------------------------------------------------------- #
+# Metric hierarchy
+# --------------------------------------------------------------------- #
+def constitutional_health(ledger: Optional[DecisionLedger] = None) -> Dict[str, Any]:
+    """Layer 1. A broken ledger chain or a recorded breach event zeroes
+    the period — nothing below can buy it back."""
+    ledger = ledger or get_ledger()
+    chain_ok, broken_at = ledger.verify_chain()
+    breaches = [e for e in ledger.entries() if e.get("event") in BREACH_EVENTS]
+    healthy = chain_ok and not breaches
+    return {
+        "healthy": healthy,
+        "gate": 1.0 if healthy else 0.0,
+        "chain_ok": chain_ok,
+        "breach_events": len(breaches),
+    }
+
+
+def evidence_quality_multiplier(session: Any) -> float:
+    """Layer 2. The average tier-weighted quality of in-window results.
+    Zero results means zero — internal activity earns nothing here."""
+    horizon = datetime.now(UTC) - timedelta(days=window_days())
+    results = [
+        r for r in session.query(ValidationResult).all()
+        if r.created_at >= horizon
+    ]
+    if not results:
+        return 0.0
+    scores = [
+        TIER_WEIGHTS.get(r.evidence_tier, 0.2) * max(0.0, min(1.0, r.evidence_quality))
+        for r in results
+    ]
+    return round(sum(scores) / len(scores), 4)
+
+
+def evidence_weighted_j(
+    base_j: float,
+    session: Any,
+    ledger: Optional[DecisionLedger] = None,
+) -> Dict[str, Any]:
+    health = constitutional_health(ledger)
+    multiplier = evidence_quality_multiplier(session)
+    return {
+        "base_j": base_j,
+        "constitutional_gate": health["gate"],
+        "evidence_multiplier": multiplier,
+        "evidence_weighted_j": round(base_j * multiplier * health["gate"], 4),
+    }
+
+
+def institutional_metrics(
+    session: Any,
+    ledger: Optional[DecisionLedger] = None,
+    base_j: Optional[float] = None,
+) -> Dict[str, Any]:
+    """The numbers the institution actually grows by."""
+    from services.decision_episode import loop_closure_rate
+
+    ledger = ledger or get_ledger()
+    results = session.query(ValidationResult).all()
+    negatives = [r for r in results if r.result_classification == "negative"]
+    decided = [
+        r for r in session.query(ApprovalRequest).all()
+        if r.decided_at is not None and r.decided_via != "expiry"
+    ]
+    latencies = sorted((r.decided_at - r.created_at).total_seconds() for r in decided)
+
+    metrics: Dict[str, Any] = {
+        "constitutional_health": constitutional_health(ledger),
+        "evidence_window": evidence_window(session),
+        "evidence_multiplier": evidence_quality_multiplier(session),
+        **loop_closure_rate(session, ledger=ledger),
+        "validation_results_total": len(results),
+        "negative_results_retained": len(negatives),
+        "negative_retention_rate": (len(negatives) / len(results)) if results else 0.0,
+        "founder_decisions": len(decided),
+        "median_approval_latency_seconds": latencies[len(latencies) // 2] if latencies else None,
+    }
+    if base_j is not None:
+        metrics["evidence_weighted"] = evidence_weighted_j(base_j, session, ledger)
+    return metrics
+
+
+__all__ = [
+    "WORK_CATEGORIES", "ALWAYS_PERMITTED", "TIER_WEIGHTS",
+    "window_days", "evidence_window", "evaluate_work",
+    "constitutional_health", "evidence_quality_multiplier",
+    "evidence_weighted_j", "institutional_metrics",
+]

--- a/tests/test_evidence_policy.py
+++ b/tests/test_evidence_policy.py
@@ -1,0 +1,146 @@
+"""Anti-cathedral policy and the lexicographic metric hierarchy: internal
+expansion is denied while the evidence window is empty; a constitutional
+breach hard-zeros the period; zero external evidence means zero
+evidence-weighted progress, however busy the machine was."""
+
+from db.models import OpportunityPacket, ValidationResult
+from db.session import get_db_session, init_db
+from services.evidence_policy import (
+    constitutional_health,
+    evaluate_work,
+    evidence_quality_multiplier,
+    evidence_weighted_j,
+    evidence_window,
+    institutional_metrics,
+)
+from services.ledger import DecisionLedger, set_shared_instances, reset_shared_instances
+
+
+def _setup(tmp_path):
+    init_db()
+    ledger = DecisionLedger(path=str(tmp_path / "l.jsonl"))
+    set_shared_instances(ledger=ledger)
+    return ledger
+
+
+def _record_result(session, tier="conversation", quality=0.6, classification="success"):
+    packet = OpportunityPacket(source="operator", core_thesis="t", evidence=["e"])
+    session.add(packet)
+    session.add(ValidationResult(
+        opportunity_packet_id=packet.id,
+        evidence_tier=tier, evidence_quality=quality,
+        result_classification=classification,
+    ))
+    session.commit()
+
+
+def test_empty_window_denies_internal_expansion_permits_repairs(tmp_path):
+    ledger = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            assert evidence_window(session)["empty"] is True
+
+            denied = evaluate_work(session, "internal_expansion",
+                                   description="a seventh dashboard", ledger=ledger)
+            assert denied["allowed"] is False
+
+            for category in ("security_repair", "compliance_repair",
+                             "critical_reliability_repair",
+                             "external_evidence_producing",
+                             "unblocks_external_evidence"):
+                assert evaluate_work(session, category, ledger=ledger)["allowed"] is True
+
+            unknown = evaluate_work(session, "vibes_expansion", ledger=ledger)
+            assert unknown["allowed"] is False
+        # Refusals are institutional memory.
+        decisions = ledger.replay("anti_cathedral_decision")
+        assert any(d["payload"]["allowed"] is False for d in decisions)
+    finally:
+        reset_shared_instances()
+
+
+def test_nonempty_window_permits_internal_expansion(tmp_path):
+    ledger = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            _record_result(session)
+            decision = evaluate_work(session, "internal_expansion", ledger=ledger)
+        assert decision["allowed"] is True
+        assert decision["window"]["validation_results"] == 1
+    finally:
+        reset_shared_instances()
+
+
+def test_constitutional_breach_hard_zeros_the_period(tmp_path):
+    ledger = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            _record_result(session, tier="payment", quality=1.0)
+            healthy = evidence_weighted_j(10.0, session, ledger)
+            assert healthy["constitutional_gate"] == 1.0
+            assert healthy["evidence_weighted_j"] > 0.0
+
+            ledger.record("constitutional_violation", {"detail": "test breach"})
+            breached = evidence_weighted_j(10.0, session, ledger)
+        assert breached["constitutional_gate"] == 0.0
+        assert breached["evidence_weighted_j"] == 0.0  # nothing buys it back
+    finally:
+        reset_shared_instances()
+
+
+def test_broken_chain_zeroes_health(tmp_path):
+    path = tmp_path / "l.jsonl"
+    ledger = _setup(tmp_path)
+    try:
+        ledger.record("boot", {})
+        lines = path.read_text().splitlines()
+        lines[0] = lines[0].replace("boot", "tampered")
+        path.write_text("\n".join(lines) + "\n")
+        health = constitutional_health(DecisionLedger(path=str(path)))
+        assert health["gate"] == 0.0
+    finally:
+        reset_shared_instances()
+
+
+def test_zero_external_evidence_means_zero_progress(tmp_path):
+    ledger = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            assert evidence_quality_multiplier(session) == 0.0
+            weighted = evidence_weighted_j(100.0, session, ledger)
+        # However large the internal J, no reality contact -> no progress.
+        assert weighted["evidence_weighted_j"] == 0.0
+    finally:
+        reset_shared_instances()
+
+
+def test_payment_tier_outweighs_observation(tmp_path):
+    _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            _record_result(session, tier="observation", quality=1.0)
+            low = evidence_quality_multiplier(session)
+        init_db()
+        with get_db_session() as session:
+            _record_result(session, tier="payment", quality=1.0)
+            high = evidence_quality_multiplier(session)
+        assert high > low
+    finally:
+        reset_shared_instances()
+
+
+def test_institutional_metrics_report(tmp_path):
+    ledger = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            _record_result(session, classification="negative")
+            _record_result(session, tier="commitment", quality=0.8)
+            metrics = institutional_metrics(session, ledger=ledger, base_j=5.0)
+
+        assert metrics["validation_results_total"] == 2
+        assert metrics["negative_results_retained"] == 1
+        assert 0 < metrics["negative_retention_rate"] < 1
+        assert metrics["episodes"] == 2 and metrics["closed"] == 2
+        assert metrics["evidence_weighted"]["evidence_weighted_j"] > 0.0
+    finally:
+        reset_shared_instances()


### PR DESCRIPTION
## Problem

Two doctrine rules existed only as prose: (1) the anti-cathedral rule — no internal expansion while the institution has zero external evidence — and (2) the principle that no amount of output can buy its way past constitutional health. Prose rules don't bind a machine.

## Implementation

- `services/evidence_policy.py`:
  - **`evaluate_work`** — classifies proposed work into six categories and *denies* `internal_expansion` while the external-evidence window (`EVIDENCE_WINDOW_DAYS`, default 14) contains zero ValidationResults. Security/compliance/critical repairs and evidence-producing/unblocking work stay permitted. Unknown categories are denied. Every decision is ledgered (`anti_cathedral_decision`).
  - **Metric hierarchy** — `constitutional_health` (broken ledger chain or `constitutional_violation` event → gate 0.0), `evidence_quality_multiplier` (tier-weighted: payment 1.0 > commitment 0.8 > conversation 0.6 > engagement 0.4 > observation 0.2; zero results → 0.0), and **Evidence-Weighted J = goal-aligned J × multiplier × gate**. Existing J-score/analytics untouched — this layers on top.
  - **`institutional_metrics`** — loop-closure rate, negative-result retention, founder-decision load, median approval latency.
- `app.py`: `POST /api/policy/work-check`, `GET /api/metrics/institutional?base_j=`.

## Constitutional rationale

Invariant 12 becomes code: the institution cannot become a sophisticated procrastination machine, and its own scoring cannot reward it for trying. A breach or tampered ledger hard-zeros the period; nothing below buys it back.

## Tests

7 new: empty-window denial + repair permissions, unknown-category denial, non-empty-window permission, breach hard-zero, broken-chain zero, zero-evidence-zero-progress, tier ordering, metrics report. Full suite **282 passed**; tsc clean.

## Residual risk / rollback

The evaluator binds what consults it; CI-level enforcement can follow once real CI exists in this repo. Rollback: revert — additive only.

**Stacked on PR #50. Next: WMI adversarial critics.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjuRe9SzeRJf5RMnPFzeRB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjuRe9SzeRJf5RMnPFzeRB)_