### PR TITLE
Harden DALEOBANKS for UAT sibling-service integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,11 +17,11 @@ X_ACCESS_TOKEN=
 X_ACCESS_SECRET=
 
 # === Security ===
-ADMIN_TOKEN=choose-a-long-random-string
-JWT_SECRET=change-me-please
-JWT_ISSUER=
-JWT_AUDIENCE=
-ALLOWED_ORIGINS=*
+ADMIN_TOKEN=change-me-admin-token-at-least-32-bytes
+JWT_SECRET=change-me-jwt-secret-at-least-32-bytes
+JWT_ISSUER=daleobanks-local
+JWT_AUDIENCE=daleobanks-dashboard-local
+ALLOWED_ORIGINS=http://localhost:5000
 ALLOWED_IPS=
 REQUEST_ID_HEADER=X-Request-ID
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      APP_ENV: dev
+      LIVE: "false"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -r requirements.txt
+      - run: pytest -q
+
+  web:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci --no-audit --no-fund
+      - run: npm run check
+      - run: npm run build
+      - run: npm audit --omit=dev --audit-level=high

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
-# DaLeoBanks - Autonomous AI Agent
+# DaLeoBanks - Governed AI Agent
 
-DaLeoBanks is a production-grade, self-evolving AI agent that operates on Twitter/X. The stack pairs a Python FastAPI backend (agent logic, scheduler, persona management) with a Node/Express + Vite frontend that proxies requests to the backend.
+DaLeoBanks is a human-governed AI-agent implementation for bounded Twitter/X
+research, drafting, optimization, approval, and optionally armed operation. The
+stack pairs a Python FastAPI backend with a Node/Express + Vite frontend. Passing
+tests and builds do not by themselves establish production-grade assurance.
 
 ## Features
-- 24/7 autonomous operation with persona-driven content generation
+- dry-run-by-default scheduled operation with an explicit arming ceremony
 - Thompson-sampling optimization, analytics, and reflection loops
 - FastAPI backend with REST and WebSocket support
 - React + Vite frontend served through an Express proxy that also spawns the backend
 
 ## Prerequisites
 - Python 3.11+
-- Node.js 18+
+- Node.js 20+
 - Twitter/X API credentials (for live posting)
 - OpenAI API key
 
@@ -24,6 +27,8 @@ cp .env.example .env
 Key variables:
 - **OPENAI_API_KEY** and **X_* tokens** for LLM + Twitter access
 - **ADMIN_TOKEN** and **JWT_SECRET** for admin/auth endpoints
+- **JWT_ISSUER**, **JWT_AUDIENCE**, and an explicit **ALLOWED_ORIGINS** allowlist
+  are mandatory when `APP_ENV=production`
 - **LIVE** toggles autonomous posting; keep `false` for local testing
 - **PORT/BACKEND_PORT** control the Express proxy and Python backend ports
 - **PLATFORM_WEIGHTS, ENABLE_* flags** tune platform routing and feature toggles
@@ -38,8 +43,8 @@ source venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
 
-# Node
-npm install
+# Node (reproducible lockfile install)
+npm ci
 ```
 
 ## Running locally
@@ -77,7 +82,6 @@ Steps:
 After the stack is running:
 - Backend health: `curl http://localhost:5001/api/health`
 - Proxied health (through Express): `curl http://localhost:5000/api/health`
-- Config snapshot: `curl http://localhost:5001/config`
 
 ## Project structure
 - `app.py` – FastAPI application and scheduler bootstrap
@@ -90,10 +94,41 @@ After the stack is running:
 
 ## Safety & operations notes
 - Keep `LIVE=false` until credentials and guardrails are fully validated.
-- Update `ALLOWED_ORIGINS` and `ALLOWED_IPS` before exposing publicly.
+- Production startup rejects placeholder admin/JWT secrets, missing issuer or
+  audience bindings, and wildcard origins.
+- Private dashboard, venture, persona, analytics, and draft reads require a
+  validated identity. Consequential mutations require the admin role.
+- The browser keeps the short-lived admin JWT in tab-scoped session storage;
+  a public production deployment still requires independent XSS, session,
+  proxy, and recovery review.
 - Rotate `ADMIN_TOKEN` and `JWT_SECRET` regularly in production.
 - Every publish, identity change, lesson, and gate decision is recorded in a
   tamper-evident decision ledger (`data/decision_ledger.jsonl`). A broken
   chain or repeated job failures automatically disarm live posting. See
   [docs/SAFETY_AND_ROLLOUT.md](docs/SAFETY_AND_ROLLOUT.md) for the safety
   spine and the discipline for rolling out new platforms.
+
+## UAT sibling-service contract
+
+DALEOBANKS can exchange a schema-1.0 `OpportunityPacket` with
+`dababiyoda/WealthMachineIntelligence`, but the runtime integration is currently
+held: no approved production URL, service identity, durable reconciliation, or
+execution authority is configured. The ChatGPT Site may record an activation
+intent; it may not store this service's secret or call it directly. See
+[docs/UAT_WEBSITE_INTEGRATION.md](docs/UAT_WEBSITE_INTEGRATION.md) and
+[`services/uat_integration_manifest.json`](services/uat_integration_manifest.json).
+
+LIVE PLAYER is UAT agent context, not a DALEOBANKS connector or authority
+grant, and is excluded from the current service protocol.
+
+## Verification
+
+```bash
+pytest -q
+npm run check
+npm run build
+npm audit --omit=dev --audit-level=high
+```
+
+The hardening branch currently passes 264 Python tests, TypeScript checking, a
+production web build, and a zero-vulnerability high-severity runtime npm audit.

--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from pydantic import BaseModel, ValidationError
 
-from config import get_config, update_config
+from config import get_config, update_config, validate_production_security
 from db.session import init_db, get_db_session
 from db.models import *
 from services.persona_store import PersonaStore
@@ -46,6 +46,8 @@ from services.venture_protocol import validate_assessment_wire, validate_identit
 from services.security import (
     RequestContext,
     get_request_context,
+    require_authenticated,
+    require_websocket_authenticated,
     require_role,
     require_any_role,
 )
@@ -76,7 +78,7 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=config.ALLOWED_ORIGINS or ["*"],
-    allow_credentials=True,
+    allow_credentials=bool(config.ALLOWED_ORIGINS) and "*" not in config.ALLOWED_ORIGINS,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -175,7 +177,10 @@ class OpportunityCreateRequest(BaseModel):
 
 # WebSocket endpoint for real-time updates
 @app.websocket("/ws")
-async def websocket_endpoint(websocket: WebSocket):
+async def websocket_endpoint(
+    websocket: WebSocket,
+    _: RequestContext = Depends(require_websocket_authenticated),
+):
     await websocket.accept()
     websocket_connections.append(websocket)
     logger.info("WebSocket connection established")
@@ -254,7 +259,7 @@ async def broadcast_update(data: Dict[str, Any]):
 # Dashboard API endpoints
 @app.get("/api/dashboard")
 @app.get("/dashboard")  # Support both routes
-async def get_dashboard(_: RequestContext = Depends(get_request_context)):
+async def get_dashboard(_: RequestContext = Depends(require_authenticated)):
     """Get dashboard overview data"""
     try:
         with get_db_session() as session:
@@ -303,7 +308,10 @@ async def get_dashboard(_: RequestContext = Depends(get_request_context)):
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/api/crisis")
-async def set_crisis(request: CrisisRequest):
+async def set_crisis(
+    request: CrisisRequest,
+    _: RequestContext = Depends(require_role("admin")),
+):
     """Toggle crisis mode manually from the dashboard."""
     if request.active:
         runner.crisis_service.activate(reason=request.reason or "manual_toggle")
@@ -325,12 +333,16 @@ async def issue_admin_token(request: TokenRequest):
     """
     import jwt as pyjwt
 
+    if not admin_limiter.allow_request("admin_token_exchange"):
+        raise HTTPException(status_code=429, detail="Too many token requests")
+
     if not secrets.compare_digest(request.admin_token, config.ADMIN_TOKEN):
         logger.warning("Admin token exchange failed: invalid token")
+        get_ledger().record("admin_token_rejected", {"reason": "invalid_token"})
         raise HTTPException(status_code=401, detail="Invalid admin token")
 
     now = datetime.now(UTC)
-    expires_hours = 12
+    expires_hours = 1
     claims: Dict[str, Any] = {
         "sub": "admin",
         "roles": ["admin"],
@@ -367,7 +379,10 @@ async def _arming_preflight() -> Dict[str, Any]:
 
 
 @app.post("/api/toggle")
-async def toggle_live_mode(request: ToggleRequest):
+async def toggle_live_mode(
+    request: ToggleRequest,
+    _: RequestContext = Depends(require_role("admin")),
+):
     """Toggle LIVE mode. Arming requires a preflight; disarming never does."""
     try:
         if request.live:
@@ -412,7 +427,10 @@ async def reset_heartbeat_breaker(_: RequestContext = Depends(require_role("admi
     }
 
 @app.post("/api/mode")
-async def set_goal_mode(request: ModeRequest):
+async def set_goal_mode(
+    request: ModeRequest,
+    _: RequestContext = Depends(require_role("admin")),
+):
     """Set goal mode (FAME/MONETIZE)"""
     try:
         if request.mode not in ["FAME", "MONETIZE"]:
@@ -428,12 +446,14 @@ async def set_goal_mode(request: ModeRequest):
         
         logger.info(f"Goal mode set to {config.GOAL_MODE}")
         return {"mode": config.GOAL_MODE}
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Mode change error: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/api/propose")
-async def trigger_proposal():
+async def trigger_proposal(_: RequestContext = Depends(require_role("admin"))):
     """Trigger immediate proposal generation"""
     try:
         if not config.LIVE:
@@ -452,12 +472,17 @@ async def trigger_proposal():
             return {"success": True, "proposal": result}
         else:
             return {"success": False, "reason": "Not appropriate time for proposal"}
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Proposal generation error: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/api/note")
-async def add_note(request: NoteRequest):
+async def add_note(
+    request: NoteRequest,
+    _: RequestContext = Depends(require_role("admin")),
+):
     """Add improvement note"""
     try:
         with get_db_session() as session:
@@ -480,7 +505,10 @@ async def add_note(request: NoteRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/api/redirect")
-async def create_redirect(request: RedirectRequest):
+async def create_redirect(
+    request: RedirectRequest,
+    _: RequestContext = Depends(require_role("admin")),
+):
     """Create tracked redirect link"""
     try:
         with get_db_session() as session:
@@ -533,7 +561,7 @@ async def record_conversion(
 
 
 @app.get("/api/conversions")
-async def list_conversions(limit: int = 50, _: RequestContext = Depends(get_request_context)):
+async def list_conversions(limit: int = 50, _: RequestContext = Depends(require_authenticated)):
     """List recorded revenue events, newest first."""
     try:
         with get_db_session() as session:
@@ -563,7 +591,7 @@ async def list_conversions(limit: int = 50, _: RequestContext = Depends(get_requ
 
 
 @app.get("/api/discoveries")
-async def list_discoveries(status_filter: str = "pending", _: RequestContext = Depends(get_request_context)):
+async def list_discoveries(status_filter: str = "pending", _: RequestContext = Depends(require_authenticated)):
     """List discovery proposals (new voices/keywords) awaiting review."""
     try:
         with get_db_session() as session:
@@ -631,7 +659,7 @@ async def decide_discovery(
 
 
 @app.get("/api/goals/proposals")
-async def list_goal_proposals(status_filter: str = "pending", _: RequestContext = Depends(get_request_context)):
+async def list_goal_proposals(status_filter: str = "pending", _: RequestContext = Depends(require_authenticated)):
     """List proposed OKR changes awaiting human review."""
     try:
         with get_db_session() as session:
@@ -698,7 +726,7 @@ async def decide_goal_proposal(
 
 
 @app.get("/api/operator/requests")
-async def list_operator_requests(status_filter: str = "pending", _: RequestContext = Depends(get_request_context)):
+async def list_operator_requests(status_filter: str = "pending", _: RequestContext = Depends(require_authenticated)):
     """The operator's approval inbox (dashboard fallback for SMS)."""
     try:
         with get_db_session() as session:
@@ -804,7 +832,7 @@ async def intake_idea(request: IdeaIntakeRequest, _: RequestContext = Depends(re
 
 
 @app.get("/api/ideas")
-async def list_ideas(_: RequestContext = Depends(get_request_context)):
+async def list_ideas(_: RequestContext = Depends(require_authenticated)):
     with get_db_session() as session:
         ideas = session.query(Idea).order_by(lambda i: i.created_at, descending=True).all()
         return {"count": len(ideas), "ideas": [{
@@ -886,7 +914,7 @@ async def create_opportunity(
 
 
 @app.get("/api/opportunities")
-async def list_opportunities(status_filter: str = "", _: RequestContext = Depends(get_request_context)):
+async def list_opportunities(status_filter: str = "", _: RequestContext = Depends(require_authenticated)):
     with get_db_session() as session:
         packets = (
             session.query(OpportunityPacket)
@@ -1002,7 +1030,7 @@ async def receive_assessment(
 
 
 @app.get("/api/assessments")
-async def list_assessments(_: RequestContext = Depends(get_request_context)):
+async def list_assessments(_: RequestContext = Depends(require_authenticated)):
     """VentureAssessments stored so far (mock or real engine — same contract)."""
     with get_db_session() as session:
         assessments = (
@@ -1016,7 +1044,7 @@ async def list_assessments(_: RequestContext = Depends(get_request_context)):
 
 
 @app.get("/api/media/drafts")
-async def list_media_drafts(status_filter: str = "pending", _: RequestContext = Depends(get_request_context)):
+async def list_media_drafts(status_filter: str = "pending", _: RequestContext = Depends(require_authenticated)):
     with get_db_session() as session:
         drafts = (
             session.query(MediaAssetDraft)
@@ -1061,7 +1089,7 @@ async def decide_media_draft(
 
 
 @app.get("/api/lanes")
-async def list_lanes(_: RequestContext = Depends(get_request_context)):
+async def list_lanes(_: RequestContext = Depends(require_authenticated)):
     with get_db_session() as session:
         lanes = session.query(AccountLane).all()
         return {"count": len(lanes), "policy": list(LANE_POLICY), "lanes": [{
@@ -1133,7 +1161,7 @@ async def health_check():
 
 # Reflection / learned-mind endpoints
 @app.get("/api/reflections")
-async def get_reflections(limit: int = 20, _: RequestContext = Depends(get_request_context)):
+async def get_reflections(limit: int = 20, _: RequestContext = Depends(require_authenticated)):
     """Return the agent's most recent learned lessons (its evolving 'mind')."""
     try:
         with get_db_session() as session:
@@ -1157,7 +1185,7 @@ async def trigger_reflection(_: RequestContext = Depends(require_role("admin")))
 
 # Persona management endpoints
 @app.get("/api/persona")
-async def get_persona():
+async def get_persona(_: RequestContext = Depends(require_authenticated)):
     """Get current persona"""
     try:
         return persona_store.get_current_persona()
@@ -1166,7 +1194,7 @@ async def get_persona():
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/api/persona/versions")
-async def get_persona_versions():
+async def get_persona_versions(_: RequestContext = Depends(require_authenticated)):
     """Get persona version history"""
     try:
         with get_db_session() as session:
@@ -1252,7 +1280,7 @@ async def rollback_persona(version: int, _: RequestContext = Depends(require_rol
 
 @app.get("/api/analytics")
 @app.get("/analytics")  # Support both routes
-async def get_analytics(_: RequestContext = Depends(get_request_context)):
+async def get_analytics(_: RequestContext = Depends(require_authenticated)):
     """Get analytics data"""
     try:
         with get_db_session() as session:
@@ -1271,6 +1299,11 @@ async def startup_event():
     """Initialize application on startup"""
     try:
         logger.info("Starting DaLeoBanks AI Agent...")
+
+        # Refuse production startup with placeholder credentials or wildcard
+        # credentialed origins.  This check is deterministic and outside the
+        # model/agent layer.
+        validate_production_security(config)
 
         # Initialize database
         init_db()

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -10,14 +10,14 @@ async function throwIfResNotOk(res: Response) {
 const ADMIN_JWT_KEY = "daleobanks-admin-jwt";
 
 export function getAdminJwt(): string | null {
-  return localStorage.getItem(ADMIN_JWT_KEY);
+  return sessionStorage.getItem(ADMIN_JWT_KEY);
 }
 
 export function setAdminJwt(token: string | null): void {
   if (token) {
-    localStorage.setItem(ADMIN_JWT_KEY, token);
+    sessionStorage.setItem(ADMIN_JWT_KEY, token);
   } else {
-    localStorage.removeItem(ADMIN_JWT_KEY);
+    sessionStorage.removeItem(ADMIN_JWT_KEY);
   }
 }
 
@@ -52,6 +52,7 @@ export const getQueryFn: <T>(options: {
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
     const res = await fetch(queryKey.join("/") as string, {
+      headers: authHeaders(),
       credentials: "include",
     });
 

--- a/client/src/pages/configuration.tsx
+++ b/client/src/pages/configuration.tsx
@@ -17,7 +17,7 @@ export default function Configuration() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [goalMode, setGoalMode] = useState("FAME");
-  const [liveMode, setLiveMode] = useState(true);
+  const [liveMode, setLiveMode] = useState(false);
 
   const { data: config, isLoading } = useQuery<DashboardResponse>({
     queryKey: ["/api/dashboard"],
@@ -27,7 +27,7 @@ export default function Configuration() {
   useEffect(() => {
     if (config) {
       setGoalMode(config.goal_mode || "FAME");
-      setLiveMode(config.system_status?.live_mode ?? true);
+      setLiveMode(config.system_status?.live_mode ?? false);
     }
   }, [config]);
 
@@ -217,20 +217,20 @@ export default function Configuration() {
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
                     <span className="text-sm">Twitter/X API</span>
-                    <Badge className="bg-green-100 dark:bg-green-900/20 text-green-700 dark:text-green-400">
-                      Connected
+                    <Badge variant="secondary">
+                      {config?.system_status?.api_health === "healthy" ? "Runtime healthy" : "Not verified"}
                     </Badge>
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-sm">OpenAI API</span>
-                    <Badge className="bg-green-100 dark:bg-green-900/20 text-green-700 dark:text-green-400">
-                      Connected
+                    <Badge variant="secondary">
+                      Verify server-side
                     </Badge>
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-sm">Rate Limits</span>
-                    <Badge className="bg-blue-100 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400">
-                      Healthy
+                    <Badge variant="secondary">
+                      {config?.system_status?.rate_limits || "Not verified"}
                     </Badge>
                   </div>
                 </div>

--- a/config.py
+++ b/config.py
@@ -166,8 +166,8 @@ def _build_config() -> Config:
         X_API_SECRET=os.getenv("X_API_SECRET"),
         X_ACCESS_TOKEN=os.getenv("X_ACCESS_TOKEN"),
         X_ACCESS_SECRET=os.getenv("X_ACCESS_SECRET"),
-        ADMIN_TOKEN=os.getenv("ADMIN_TOKEN", "choose-a-long-random-string"),
-        JWT_SECRET=os.getenv("JWT_SECRET", "change-me-please"),
+        ADMIN_TOKEN=os.getenv("ADMIN_TOKEN", "change-me-admin-token-at-least-32-bytes"),
+        JWT_SECRET=os.getenv("JWT_SECRET", "change-me-jwt-secret-at-least-32-bytes"),
         JWT_ISSUER=os.getenv("JWT_ISSUER", None),
         JWT_AUDIENCE=os.getenv("JWT_AUDIENCE", None),
 
@@ -257,6 +257,46 @@ def _notify_listeners(changes: Dict[str, Any]) -> None:
         except Exception:
             # Listeners should not break config updates; ignore failures.
             continue
+
+
+def validate_production_security(cfg: Config) -> None:
+    """Reject production startup when identity or origin controls are unsafe.
+
+    Development may use local placeholders while LIVE remains off.  Production
+    must never silently inherit repository defaults.
+    """
+    if cfg.APP_ENV.lower() not in {"prod", "production"}:
+        return
+
+    errors: List[str] = []
+    placeholder_admin_tokens = {
+        "",
+        "choose-a-long-random-string",
+        "change-me-admin-token-at-least-32-bytes",
+        "change-me",
+        "changeme",
+    }
+    placeholder_jwt_secrets = {
+        "",
+        "change-me-please",
+        "change-me-jwt-secret-at-least-32-bytes",
+        "change-me",
+        "changeme",
+    }
+
+    if cfg.ADMIN_TOKEN.lower() in placeholder_admin_tokens or len(cfg.ADMIN_TOKEN) < 32:
+        errors.append("ADMIN_TOKEN must be a non-placeholder secret of at least 32 characters")
+    if cfg.JWT_SECRET.lower() in placeholder_jwt_secrets or len(cfg.JWT_SECRET) < 32:
+        errors.append("JWT_SECRET must be a non-placeholder secret of at least 32 characters")
+    if not cfg.JWT_ISSUER:
+        errors.append("JWT_ISSUER is required in production")
+    if not cfg.JWT_AUDIENCE:
+        errors.append("JWT_AUDIENCE is required in production")
+    if not cfg.ALLOWED_ORIGINS or "*" in cfg.ALLOWED_ORIGINS:
+        errors.append("ALLOWED_ORIGINS must be an explicit production allowlist")
+
+    if errors:
+        raise RuntimeError("Unsafe production configuration: " + "; ".join(errors))
 
 
 def get_config() -> Config:

--- a/docs/UAT_WEBSITE_INTEGRATION.md
+++ b/docs/UAT_WEBSITE_INTEGRATION.md
@@ -1,0 +1,64 @@
+# DALEOBANKS -> UAT website integration contract
+
+## Current decision
+
+DALEOBANKS is a separate sibling service. The ChatGPT Site must not embed it,
+receive its production secret, or treat a connection request as a live runtime
+connection. The existing versioned exchange remains server-to-server and held
+for human review:
+
+`DALEOBANKS OpportunityPacket -> UAT VentureAssessment -> DALEOBANKS drafts and approval request`
+
+Both repositories implement the schema-1.0 compatibility shape. That proves a
+contract, not delivery, authorization, payment, venture creation, or external
+execution.
+
+## Authority boundary
+
+- DALEOBANKS discovers or receives an opportunity and records it locally.
+- An administrator approves the packet before transmission.
+- UAT validates and records the packet, then returns a held assessment.
+- DALEOBANKS forces `requires_human_approval=true` and creates reviewable drafts.
+- Neither service may translate an assessment into publishing, spending,
+  contracting, deployment, or venture launch without a separate governed
+  action and designated human approval.
+- The website may record an activation **request** and display status. It may
+  not store the service credential or call either service directly.
+
+## LIVE PLAYER separation
+
+LIVE PLAYER is UAT agent context, not a DALEOBANKS integration. It must remain
+outside this protocol unless a future, separately approved data-flow contract
+defines an exact context version, purpose, fields, retention rule, and redaction
+policy. Context can influence a bounded recommendation; it cannot grant a tool,
+role, credential, budget, or execution authority.
+
+## Current transport
+
+DALEOBANKS supports `mock` and `http` modes. HTTP sends a schema-1.0 packet to
+`{WEALTHMACHINE_URL}/api/opportunities/intake` with the optional
+`WEALTHMACHINE_INTAKE_TOKEN`. UAT fails closed in production if its matching
+intake token is absent. This static-token compatibility mode is suitable for a
+bounded sandbox only; production acceptance requires scoped, rotated or
+short-lived workload credentials.
+
+## Production activation gates
+
+1. Name service owners and approve exact sandbox and production endpoints.
+2. Enforce authenticated administration on every DALEOBANKS mutation and
+   authenticated access to private operator data.
+3. Replace placeholder secrets and wildcard origins; bind JWT issuer and
+   audience.
+4. Add a durable outbox/inbox with message ID, idempotency key, attempt,
+   timestamp, contract version, payload hash, receipt, and terminal state.
+5. Test duplicate, delayed, reordered, replayed, malformed, expired, and
+   partially processed messages.
+6. Reconcile each transmission and assessment against both authoritative
+   stores; never infer completion from an HTTP request alone.
+7. Add rate limits, circuit breaking, schema-drift holds, kill switches, and
+   incident ownership.
+8. Prove that approval cannot be self-issued by the proposing service or agent.
+9. Complete security, privacy, legal, and recovery review.
+
+Until every gate is evidenced, `runtime_status=not_configured` and
+`execution_authority=none` are mandatory customer-facing labels.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,13 +46,12 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
-        "drizzle-orm": "^0.39.1",
-        "drizzle-zod": "^0.7.0",
+        "drizzle-orm": "^0.45.2",
+        "drizzle-zod": "^0.7.1",
         "embla-carousel-react": "^8.6.0",
-        "express": "^4.21.2",
-        "express-session": "^1.18.1",
+        "express": "^5.2.1",
         "framer-motion": "^11.13.1",
-        "http-proxy-middleware": "^3.0.5",
+        "http-proxy-middleware": "^4.2.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.453.0",
         "memorystore": "^1.6.7",
@@ -71,7 +70,7 @@
         "tw-animate-css": "^1.2.5",
         "vaul": "^1.1.2",
         "wouter": "^3.3.5",
-        "ws": "^8.18.0",
+        "ws": "^8.21.1",
         "zod": "^3.24.2",
         "zod-validation-error": "^3.4.0"
       },
@@ -81,8 +80,7 @@
         "@tailwindcss/typography": "^0.5.15",
         "@tailwindcss/vite": "^4.1.3",
         "@types/connect-pg-simple": "^7.0.3",
-        "@types/express": "4.17.21",
-        "@types/express-session": "^1.18.0",
+        "@types/express": "5.0.6",
         "@types/node": "20.16.11",
         "@types/passport": "^1.0.16",
         "@types/passport-local": "^1.0.38",
@@ -93,7 +91,7 @@
         "autoprefixer": "^10.4.20",
         "drizzle-kit": "^0.30.4",
         "esbuild": "^0.25.0",
-        "postcss": "^8.4.47",
+        "postcss": "^8.5.19",
         "tailwindcss": "^3.4.17",
         "tsx": "^4.19.1",
         "typescript": "5.6.3",
@@ -352,12 +350,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3377,9 +3373,9 @@
       }
     },
     "node_modules/@types/d3-array": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
-      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
@@ -3404,33 +3400,33 @@
       }
     },
     "node_modules/@types/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
-      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-time": "*"
       }
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
-      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
       }
     },
     "node_modules/@types/d3-time": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
-      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
       "license": "MIT"
     },
     "node_modules/@types/d3-timer": {
@@ -3447,22 +3443,21 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
+      "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3483,25 +3478,9 @@
       }
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/http-proxy": {
-      "version": "1.17.16",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
-      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3566,9 +3545,9 @@
       "license": "MIT"
     },
     "node_modules/@types/qs": {
-      "version": "6.9.16",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
-      "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3601,26 +3580,24 @@
       }
     },
     "node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
+        "@types/node": "*"
       }
     },
     "node_modules/@types/ws": {
@@ -3654,13 +3631,13 @@
       }
     },
     "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -3727,12 +3704,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -3790,48 +3761,46 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
+    "node_modules/body-parser/node_modules/content-type": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3912,17 +3881,27 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
-        "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4071,15 +4050,16 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -4108,10 +4088,13 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4176,9 +4159,9 @@
       }
     },
     "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4276,9 +4259,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4298,23 +4281,6 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -4322,16 +4288,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -4364,6 +4320,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -4816,9 +4773,9 @@
       }
     },
     "node_modules/drizzle-orm": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.39.1.tgz",
-      "integrity": "sha512-2bDHlzTY31IDmrYn8i+ZZrxK8IyBD4mPZ7JmZdVDQj2tpBZXs/gxB/1kK5pSvkjxPUMNOVsTnoGkSltgjuJwcA==",
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
@@ -4829,24 +4786,24 @@
         "@neondatabase/serverless": ">=0.10.0",
         "@op-engineering/op-sqlite": ">=2",
         "@opentelemetry/api": "^1.4.1",
-        "@planetscale/database": ">=1",
+        "@planetscale/database": ">=1.13",
         "@prisma/client": "*",
         "@tidbcloud/serverless": "*",
         "@types/better-sqlite3": "*",
         "@types/pg": "*",
-        "@types/react": ">=18",
         "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
         "@vercel/postgres": ">=0.8.0",
         "@xata.io/client": "*",
         "better-sqlite3": ">=7",
         "bun-types": "*",
         "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
         "knex": "*",
         "kysely": "*",
         "mysql2": ">=2",
         "pg": ">=8",
         "postgres": ">=3",
-        "react": ">=18",
         "sql.js": ">=1",
         "sqlite3": ">=5"
       },
@@ -4890,10 +4847,10 @@
         "@types/pg": {
           "optional": true
         },
-        "@types/react": {
+        "@types/sql.js": {
           "optional": true
         },
-        "@types/sql.js": {
+        "@upstash/redis": {
           "optional": true
         },
         "@vercel/postgres": {
@@ -4909,6 +4866,9 @@
           "optional": true
         },
         "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
           "optional": true
         },
         "knex": {
@@ -4929,9 +4889,6 @@
         "prisma": {
           "optional": true
         },
-        "react": {
-          "optional": true
-        },
         "sql.js": {
           "optional": true
         },
@@ -4941,13 +4898,27 @@
       }
     },
     "node_modules/drizzle-zod": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/drizzle-zod/-/drizzle-zod-0.7.0.tgz",
-      "integrity": "sha512-xgCRYYVEzRkeXTS33GSMgoowe3vKsMNBjSI+cwG1oLQVEhAWWbqtb/AAMlm7tkmV4fG/uJjEmWzdzlEmTgWOoQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/drizzle-zod/-/drizzle-zod-0.7.1.tgz",
+      "integrity": "sha512-nZzALOdz44/AL2U005UlmMqaQ1qe5JfanvLujiTHiiT8+vZJTBFhj3pY4Vk+L6UWyKFfNmLhk602Hn4kCTynKQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "drizzle-orm": ">=0.36.0",
         "zod": ">=3.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -5023,13 +4994,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -5039,6 +5007,18 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -5129,119 +5109,53 @@
       "license": "MIT"
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-session": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
-      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "0.7.2",
-        "cookie-signature": "1.0.7",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-headers": "~1.0.2",
-        "parseurl": "~1.3.3",
-        "safe-buffer": "5.2.1",
-        "uid-safe": "~2.1.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/express-session/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express-session/node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
-    },
-    "node_modules/express-session/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/express-session/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/express/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/express/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
     "node_modules/fast-equals": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
-      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.1.tgz",
+      "integrity": "sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -5296,56 +5210,24 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
+        "node": ">= 18.0.0"
       },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/foreground-child": {
@@ -5415,12 +5297,12 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -5457,16 +5339,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5483,6 +5370,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
@@ -5497,9 +5397,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -5539,12 +5440,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5556,34 +5457,10 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5605,62 +5482,61 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
       },
-      "engines": {
-        "node": ">=8.0.0"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.2.0.tgz",
+      "integrity": "sha512-ZA+oNOoM+GLoFTIzhkJptVQov73Srep2LBqhF8hG8CIPKO3nam1jonXVQ/QUH8RbwsmaaVz2SOJdzBNBHNtKbw==",
       "license": "MIT",
       "dependencies": {
-        "@types/http-proxy": "^1.17.15",
-        "debug": "^4.3.6",
-        "http-proxy": "^1.18.1",
+        "debug": "^4.4.3",
+        "httpxy": "^0.5.4",
         "is-glob": "^4.0.3",
-        "is-plain-object": "^5.0.0",
+        "is-plain-obj": "^4.1.0",
         "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^22.15.0 || ^24.0.0 || >=26.0.0"
       }
     },
+    "node_modules/httpxy": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.5.tgz",
+      "integrity": "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==",
+      "license": "MIT"
+    },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
@@ -5762,14 +5638,23 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6079,9 +5964,9 @@
       "license": "MIT"
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.castarray": {
@@ -6144,13 +6029,22 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/memorystore": {
@@ -6183,10 +6077,13 @@
       "license": "ISC"
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -6198,15 +6095,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/micromatch": {
@@ -6222,46 +6110,38 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6326,15 +6206,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6343,9 +6224,9 @@
       }
     },
     "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6417,9 +6298,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6446,13 +6327,13 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -6545,10 +6426,14 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pause": {
       "version": "0.0.1",
@@ -6717,9 +6602,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6747,9 +6632,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6766,8 +6651,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -6938,6 +6823,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6947,7 +6833,8 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -6969,12 +6856,13 @@
       "license": "ISC"
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -7003,37 +6891,32 @@
       ],
       "license": "MIT"
     },
-    "node_modules/random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/react": {
@@ -7172,6 +7055,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
       "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
       "dependencies": {
         "fast-equals": "^5.0.1",
         "prop-types": "^15.8.1",
@@ -7207,6 +7091,7 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -7240,9 +7125,11 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.2.tgz",
-      "integrity": "sha512-xv9lVztv3ingk7V3Jf05wfAZbM9Q2umJzu5t/cfnAK7LUslNrGT7LPBr74G+ok8kSCeFMaePmWMg0rcYOnczTw==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+      "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
@@ -7270,11 +7157,6 @@
         "decimal.js-light": "^2.4.1"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
     "node_modules/regexparam": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-3.0.0.tgz",
@@ -7283,12 +7165,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -7365,6 +7241,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7387,26 +7279,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -7434,83 +7306,48 @@
       }
     },
     "node_modules/send": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       },
       "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/send/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/send/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/send/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
+        "node": ">= 18"
       },
-      "engines": {
-        "node": ">= 0.4"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -7541,15 +7378,69 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7616,9 +7507,9 @@
       "license": "MIT"
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8353,16 +8244,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -8377,18 +8286,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/uid-safe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "license": "MIT",
-      "dependencies": {
-        "random-bytes": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/undici-types": {
@@ -8479,12 +8376,12 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -9155,10 +9052,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -9193,21 +9096,25 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -48,13 +48,12 @@
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
-    "drizzle-orm": "^0.39.1",
-    "drizzle-zod": "^0.7.0",
+    "drizzle-orm": "^0.45.2",
+    "drizzle-zod": "^0.7.1",
     "embla-carousel-react": "^8.6.0",
-    "express": "^4.21.2",
-    "express-session": "^1.18.1",
+    "express": "^5.2.1",
     "framer-motion": "^11.13.1",
-    "http-proxy-middleware": "^3.0.5",
+    "http-proxy-middleware": "^4.2.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.453.0",
     "memorystore": "^1.6.7",
@@ -73,7 +72,7 @@
     "tw-animate-css": "^1.2.5",
     "vaul": "^1.1.2",
     "wouter": "^3.3.5",
-    "ws": "^8.18.0",
+    "ws": "^8.21.1",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0"
   },
@@ -83,8 +82,7 @@
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
     "@types/connect-pg-simple": "^7.0.3",
-    "@types/express": "4.17.21",
-    "@types/express-session": "^1.18.0",
+    "@types/express": "5.0.6",
     "@types/node": "20.16.11",
     "@types/passport": "^1.0.16",
     "@types/passport-local": "^1.0.38",
@@ -95,7 +93,7 @@
     "autoprefixer": "^10.4.20",
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
-    "postcss": "^8.4.47",
+    "postcss": "^8.5.19",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
@@ -103,5 +101,13 @@
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"
+  },
+  "overrides": {
+    "brace-expansion": "2.1.2",
+    "glob": "10.5.0",
+    "lodash": "4.18.1",
+    "minimatch": "9.0.9",
+    "picomatch": "2.3.2",
+    "yaml": "2.9.0"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "daleobanks"
 version = "0.1.0"
-description = "Autonomous social AI agent with a tamper-evident safety spine"
+description = "Human-governed social AI agent with a tamper-evident safety spine"
 requires-python = ">=3.11"
 dependencies = [
     "apscheduler>=3.11.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -35,6 +35,18 @@ pythonProcess.on("exit", (code) => {
 const app = express();
 const server = createServer(app);
 
+app.disable("x-powered-by");
+app.use((_req, res, next) => {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Frame-Options", "DENY");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  if (isProduction) {
+    res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  }
+  next();
+});
+
 // Proxy API and WebSocket requests to Python backend.
 // Express strips the mount path from req.url before the proxy sees it, so
 // each proxy must re-add its prefix or the backend receives the wrong path.

--- a/services/llm_adapter.py
+++ b/services/llm_adapter.py
@@ -32,9 +32,20 @@ class LLMAdapter:
     
     def __init__(self):
         self.config = get_config()
-        self.client = openai.AsyncOpenAI(api_key=self.config.OPENAI_API_KEY)
+        # Constructing the SDK client can inspect proxy configuration and fail
+        # before the application has decided to use the model. Keep startup,
+        # dry-run operation, and template fallback independent of an external
+        # provider; create the client only for an authorized model call.
+        self.client: Optional[openai.AsyncOpenAI] = None
         self.budget = LLMBudget()
         self.template_fallback_enabled = True
+
+    def _get_client(self) -> openai.AsyncOpenAI:
+        if self.client is None:
+            if not self.config.OPENAI_API_KEY:
+                raise RuntimeError("OPENAI_API_KEY is not configured")
+            self.client = openai.AsyncOpenAI(api_key=self.config.OPENAI_API_KEY)
+        return self.client
         
     def _check_budget(self) -> bool:
         """Check if we're within budget limits"""
@@ -97,6 +108,10 @@ class LLMAdapter:
                 return self._template_fallback(system, messages)
             else:
                 raise Exception("LLM budget exceeded and template fallback disabled")
+
+        if not self.config.OPENAI_API_KEY and self.template_fallback_enabled:
+            logger.info("OpenAI is not configured, using template fallback")
+            return self._template_fallback(system, messages)
         
         try:
             # Prepare messages
@@ -105,7 +120,7 @@ class LLMAdapter:
             
             # Make API call
             start_time = time.time()
-            response = await self.client.chat.completions.create(
+            response = await self._get_client().chat.completions.create(
                 model="gpt-4o-mini",
                 messages=chat_messages,
                 temperature=temperature,

--- a/services/security.py
+++ b/services/security.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 from uuid import uuid4
 
 import jwt
-from fastapi import Depends, HTTPException, Request, status
+from fastapi import Depends, HTTPException, Request, WebSocket, WebSocketException, status
 
 from config import get_config
 from services.logging_utils import get_logger
@@ -114,6 +114,69 @@ def require_role(required_role: str):
         return context
 
     return dependency
+
+
+def require_authenticated(context: RequestContext = Depends(get_request_context)) -> RequestContext:
+    """Reject anonymous access while allowing any validated JWT role.
+
+    Read-only operator data is still sensitive: it can contain venture theses,
+    revenue, drafts, decisions, and persona history.  Callers must therefore
+    present a valid token even when no elevated role is required.
+    """
+    if context.subject == "anonymous" or "anonymous" in context.roles:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+
+    dominant_role = context.roles[0] if context.roles else "user"
+    limiter_key = f"{dominant_role}:{context.client_ip or context.subject}"
+    if not role_limiter.allow(dominant_role, limiter_key):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Rate limit exceeded for role",
+        )
+    return context
+
+
+def require_websocket_authenticated(websocket: WebSocket) -> RequestContext:
+    """Authenticate WebSocket upgrades without putting bearer tokens in URLs."""
+    config = get_config()
+    auth_header = websocket.headers.get("authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        raise WebSocketException(code=1008, reason="Authentication required")
+
+    token = auth_header.split(" ", 1)[1]
+    try:
+        claims = jwt.decode(
+            token,
+            config.JWT_SECRET,
+            algorithms=["HS256"],
+            audience=config.JWT_AUDIENCE,
+            issuer=config.JWT_ISSUER or None,
+            options={"verify_aud": bool(config.JWT_AUDIENCE)},
+        )
+    except Exception as exc:
+        logger.warning("WebSocket JWT validation failed", extra_data={"error": str(exc)})
+        raise WebSocketException(code=1008, reason="Invalid token") from exc
+
+    subject = str(claims.get("sub", "")).strip()
+    if not subject:
+        raise WebSocketException(code=1008, reason="Token subject is required")
+
+    roles = _parse_roles(claims)
+    dominant_role = roles[0] if roles else "user"
+    client_ip = websocket.client.host if websocket.client else "unknown"
+    limiter_key = f"websocket:{dominant_role}:{client_ip or subject}"
+    if not role_limiter.allow(dominant_role, limiter_key):
+        raise WebSocketException(code=1008, reason="Rate limit exceeded")
+
+    return RequestContext(
+        request_id=str(uuid4()),
+        subject=subject,
+        roles=roles,
+        client_ip=client_ip,
+    )
 
 
 def require_any_role(roles: List[str]):

--- a/services/uat_integration_manifest.json
+++ b/services/uat_integration_manifest.json
@@ -1,0 +1,50 @@
+{
+  "manifest_version": "1.0.0",
+  "service": "daleobanks",
+  "classification": "separate_sibling_service",
+  "counterparty": "dababiyoda/WealthMachineIntelligence",
+  "protocol": {
+    "schema_version": "1.0",
+    "outbound_type": "OpportunityPacket",
+    "outbound_endpoint": "/api/opportunities/intake",
+    "inbound_type": "VentureAssessment",
+    "inbound_endpoint": "/api/wealthmachine/assessments/receive",
+    "requires_human_approval": true
+  },
+  "website_boundary": {
+    "allowed": [
+      "record_activation_intent",
+      "display_contract_status",
+      "display_missing_activation_gates"
+    ],
+    "prohibited": [
+      "store_service_secret",
+      "call_daleobanks_directly",
+      "claim_live_connection_from_intent",
+      "claim_execution_from_assessment"
+    ]
+  },
+  "runtime": {
+    "status": "not_configured",
+    "execution_authority": "none",
+    "live_mode_required": false,
+    "current_auth_compatibility": "static_bearer_compatibility_uat_production_requires_token",
+    "production_auth_target": "scoped_rotated_or_short_lived_workload_identity"
+  },
+  "live_player": {
+    "classification": "uat_agent_context_not_connector",
+    "included_in_protocol": false,
+    "authority": "none"
+  },
+  "required_activation_evidence": [
+    "approved_service_owners_and_endpoints",
+    "authenticated_mutations_and_private_reads",
+    "production_identity_and_origin_configuration",
+    "durable_outbox_inbox_and_idempotency",
+    "replay_retry_timeout_and_schema_drift_tests",
+    "bidirectional_reconciliation",
+    "independent_human_approval",
+    "incident_recovery_and_contract_rollback",
+    "independent_security_privacy_legal_review"
+  ]
+}

--- a/tests/test_api_authorization.py
+++ b/tests/test_api_authorization.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import httpx
+import jwt
+import pytest
+from fastapi import WebSocketException
+
+import app as app_module
+from config import get_config, validate_production_security
+from services.security import require_websocket_authenticated
+
+
+@pytest.mark.asyncio
+async def test_consequential_mutations_reject_anonymous_callers() -> None:
+    cases = [
+        ("/api/crisis", {"active": True}),
+        ("/api/toggle", {"live": False}),
+        ("/api/mode", {"mode": "FAME"}),
+        ("/api/propose", None),
+        ("/api/note", {"text": "bounded note"}),
+        ("/api/redirect", {"label": "test", "target_url": "https://example.com"}),
+    ]
+    transport = httpx.ASGITransport(app=app_module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for path, body in cases:
+            response = await client.post(path, json=body)
+            assert response.status_code == 403, (path, response.text)
+
+
+@pytest.mark.asyncio
+async def test_private_operator_reads_require_a_valid_identity() -> None:
+    transport = httpx.ASGITransport(app=app_module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for path in ("/api/dashboard", "/api/opportunities", "/api/persona"):
+            response = await client.get(path)
+            assert response.status_code == 401, (path, response.text)
+
+        assert (await client.get("/api/health")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_authenticated_read_uses_bound_issuer_and_audience() -> None:
+    cfg = get_config()
+    claims = {"sub": "test-admin", "roles": ["admin"]}
+    if cfg.JWT_ISSUER:
+        claims["iss"] = cfg.JWT_ISSUER
+    if cfg.JWT_AUDIENCE:
+        claims["aud"] = cfg.JWT_AUDIENCE
+    token = jwt.encode(claims, cfg.JWT_SECRET, algorithm="HS256")
+
+    transport = httpx.ASGITransport(app=app_module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/api/persona",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 200, response.text
+
+
+def test_websocket_rejects_missing_bearer_identity() -> None:
+    websocket = SimpleNamespace(headers={}, client=SimpleNamespace(host="127.0.0.1"))
+
+    with pytest.raises(WebSocketException, match="Authentication required"):
+        require_websocket_authenticated(websocket)
+
+
+def test_websocket_rejects_token_without_subject() -> None:
+    cfg = get_config()
+    claims = {"roles": ["admin"]}
+    if cfg.JWT_ISSUER:
+        claims["iss"] = cfg.JWT_ISSUER
+    if cfg.JWT_AUDIENCE:
+        claims["aud"] = cfg.JWT_AUDIENCE
+    token = jwt.encode(claims, cfg.JWT_SECRET, algorithm="HS256")
+    websocket = SimpleNamespace(
+        headers={"authorization": f"Bearer {token}"},
+        client=SimpleNamespace(host="127.0.0.1"),
+    )
+
+    with pytest.raises(WebSocketException, match="Token subject is required"):
+        require_websocket_authenticated(websocket)
+
+
+def test_websocket_accepts_bound_authenticated_identity() -> None:
+    cfg = get_config()
+    claims = {"sub": "operator", "roles": ["admin"]}
+    if cfg.JWT_ISSUER:
+        claims["iss"] = cfg.JWT_ISSUER
+    if cfg.JWT_AUDIENCE:
+        claims["aud"] = cfg.JWT_AUDIENCE
+    token = jwt.encode(claims, cfg.JWT_SECRET, algorithm="HS256")
+    websocket = SimpleNamespace(
+        headers={"authorization": f"Bearer {token}"},
+        client=SimpleNamespace(host="127.0.0.1"),
+    )
+
+    context = require_websocket_authenticated(websocket)
+
+    assert context.subject == "operator"
+    assert context.roles == ["admin"]
+
+
+def test_production_configuration_rejects_placeholders_and_wildcards() -> None:
+    unsafe = replace(
+        get_config(),
+        APP_ENV="production",
+        ADMIN_TOKEN="choose-a-long-random-string",
+        JWT_SECRET="change-me-please",
+        JWT_ISSUER=None,
+        JWT_AUDIENCE=None,
+        ALLOWED_ORIGINS=["*"],
+    )
+    with pytest.raises(RuntimeError, match="Unsafe production configuration"):
+        validate_production_security(unsafe)
+
+
+def test_production_configuration_accepts_explicit_identity_and_origins() -> None:
+    safe = replace(
+        get_config(),
+        APP_ENV="production",
+        ADMIN_TOKEN="a" * 32,
+        JWT_SECRET="b" * 32,
+        JWT_ISSUER="https://auth.example.test",
+        JWT_AUDIENCE="daleobanks-api",
+        ALLOWED_ORIGINS=["https://operator.example.test"],
+    )
+    validate_production_security(safe)

--- a/tests/test_auth_token.py
+++ b/tests/test_auth_token.py
@@ -27,7 +27,7 @@ async def test_valid_admin_token_mints_admin_jwt(tmp_path):
         )
         assert claims["sub"] == "admin"
         assert claims["roles"] == ["admin"]
-        assert response["expires_in"] == 12 * 3600
+        assert response["expires_in"] == 3600
         assert ledger.replay("admin_token_issued")
     finally:
         reset_shared_instances()
@@ -45,5 +45,6 @@ async def test_wrong_admin_token_is_rejected(tmp_path):
             )
         assert exc_info.value.status_code == 401
         assert ledger.replay("admin_token_issued") == []
+        assert ledger.replay("admin_token_rejected")
     finally:
         reset_shared_instances()

--- a/tests/test_llm_adapter_lifecycle.py
+++ b/tests/test_llm_adapter_lifecycle.py
@@ -1,0 +1,36 @@
+import pytest
+
+from services.llm_adapter import LLMAdapter
+
+
+def test_adapter_does_not_construct_provider_client_at_startup(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    def fail_if_constructed(*args, **kwargs):
+        raise AssertionError("provider client must be created lazily")
+
+    monkeypatch.setattr("services.llm_adapter.openai.AsyncOpenAI", fail_if_constructed)
+
+    adapter = LLMAdapter()
+
+    assert adapter.client is None
+
+
+@pytest.mark.asyncio
+async def test_missing_provider_configuration_uses_template_fallback(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    def fail_if_constructed(*args, **kwargs):
+        raise AssertionError("fallback must not construct a provider client")
+
+    monkeypatch.setattr("services.llm_adapter.openai.AsyncOpenAI", fail_if_constructed)
+
+    adapter = LLMAdapter()
+    adapter.config.OPENAI_API_KEY = ""
+    result = await adapter.chat(
+        system="Draft a proposal",
+        messages=[{"role": "user", "content": "Test"}],
+    )
+
+    assert "Pilot:" in result
+    assert adapter.client is None

--- a/tests/test_uat_integration_manifest.py
+++ b/tests/test_uat_integration_manifest.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "services" / "uat_integration_manifest.json"
+
+
+def test_uat_integration_is_a_held_service_contract() -> None:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    assert manifest["classification"] == "separate_sibling_service"
+    assert manifest["protocol"]["schema_version"] == "1.0"
+    assert manifest["protocol"]["requires_human_approval"] is True
+    assert manifest["runtime"]["status"] == "not_configured"
+    assert manifest["runtime"]["execution_authority"] == "none"
+    assert manifest["runtime"]["live_mode_required"] is False
+
+
+def test_site_and_live_player_cannot_gain_authority() -> None:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    assert "store_service_secret" in manifest["website_boundary"]["prohibited"]
+    assert "claim_live_connection_from_intent" in (
+        manifest["website_boundary"]["prohibited"]
+    )
+    assert manifest["live_player"]["classification"] == (
+        "uat_agent_context_not_connector"
+    )
+    assert manifest["live_player"]["included_in_protocol"] is False
+    assert manifest["live_player"]["authority"] == "none"
+    assert len(manifest["required_activation_evidence"]) >= 9


### PR DESCRIPTION
## Outcome

Hardens DALEOBANKS as an independently deployable Lego-style sibling service for UAT while leaving the production bridge disabled.

**Companion Lego module:** [WealthMachineIntelligence #22](https://github.com/dababiyoda/WealthMachineIntelligence/pull/22) records the UAT owner-beta, evidence, and service/context boundary on the receiving side.

## Root cause

Private operator reads and several consequential controls could be reached without a validated identity, production defaults did not fail closed strongly enough, frontend status language overstated provider readiness, and dependency/CI evidence was incomplete.

## What changed

- requires validated identity for private reads and admin authority for consequential mutations;
- authenticates WebSocket upgrades, requires a subject, and rate-limits accepted identities;
- rate-limits and audits failed admin-token exchange, with one-hour JWTs;
- rejects placeholder production secrets, missing issuer/audience bindings, and wildcard origins;
- keeps live mode off by default and removes hard-coded provider-connected claims;
- moves the browser JWT from persistent local storage to tab-scoped session storage;
- adds response security headers and removes Express fingerprinting;
- lazily creates the OpenAI client so dry-run startup and fallback do not depend on provider/proxy state;
- updates vulnerable runtime dependencies and adds Dependabot plus blocking CI;
- adds a machine-readable UAT integration manifest and activation-gate documentation.

## Lego boundary

DALEOBANKS sends an `OpportunityPacket` 1.0 to UAT and receives a held `VentureAssessment`. Every assessment still forces `requires_human_approval=true`. The ChatGPT Site may record an activation intent, but it stores no service secret and calls neither runtime. LIVE PLAYER remains UAT context and is excluded from this protocol.

## Validation

- `pytest -q`: **264 passed**
- Python compilation: passed
- `npm ci`: passed
- `npm run check`: passed
- `npm run build`: passed
- `npm audit --omit=dev --audit-level=high`: **0 vulnerabilities**
- workflow, JSON, TOML, and whitespace parsing: passed
- GitHub CI: passed

## Deliberate holds

No production endpoint, workload credential, durable outbox/inbox, idempotent receipt, replay defense, bidirectional reconciliation, independent final-state verification, or live execution authority is configured. Those remain mandatory activation gates.