### PR TITLE
Stage 4: mirror adversarial cases in the mock evaluator

### DIFF
--- a/app.py
+++ b/app.py
@@ -1030,6 +1030,7 @@ async def receive_assessment(
                 recommended_next_action=str(payload.get("recommended_next_action") or ""),
                 requires_human_approval=True,
                 reasons=list(payload.get("reasons") or []),
+                cases=list(payload.get("cases") or []),
             )
             session.add(assessment)
             packet.status = "assessed"

--- a/db/models.py
+++ b/db/models.py
@@ -401,6 +401,7 @@ class VentureAssessment:
     recommended_next_action: str = ""
     requires_human_approval: bool = True
     reasons: List[str] = field(default_factory=list)
+    cases: List[Dict[str, Any]] = field(default_factory=list)  # adversarial cases
     created_at: datetime = field(default_factory=_utcnow)
 
 

--- a/services/adversarial_cases.py
+++ b/services/adversarial_cases.py
@@ -1,0 +1,121 @@
+"""Adversarial underwriting cases: the committee argues with itself.
+
+Every assessment carries competing cases — bull, bear, fraud/manipulation,
+incumbent response, adoption friction, do-nothing, opportunity cost. The
+critics are deterministic (testable, model-free) and may disagree;
+disagreement is preserved, never averaged away. A severe unresolved
+"against" case caps the verdict regardless of score: model or heuristic
+confidence is not authority.
+
+This module is mirrored from WealthMachineIntelligence (src/services/adversarial.py) so
+the mock evaluator and the real engine present the same case structure.
+Keep the two files field-for-field compatible.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+SEVERE = "high"
+
+
+def _case(name: str, stance: str, severity: str, argument: str,
+          resolved: bool = False) -> Dict[str, Any]:
+    return {"case": name, "stance": stance, "severity": severity,
+            "argument": argument, "resolved": resolved}
+
+
+def build_cases(packet: Dict[str, Any], opportunity_score: float,
+                market_alignment: float) -> List[Dict[str, Any]]:
+    evidence: List[str] = list(packet.get("evidence") or [])
+    monetization: List[str] = list(packet.get("monetization_paths") or [])
+    urgency = packet.get("urgency", "medium")
+    offer = packet.get("possible_offer") or "the offer"
+    cases: List[Dict[str, Any]] = []
+
+    # Bull: the strongest honest argument for.
+    bull_points = []
+    if opportunity_score >= 0.55:
+        bull_points.append(f"opportunity score {opportunity_score} clears threshold")
+    if urgency == "high":
+        bull_points.append("urgency is high — the pain is current, not hypothetical")
+    if monetization:
+        bull_points.append(f"{len(monetization)} monetization paths identified")
+    cases.append(_case(
+        "bull", "for", "medium" if bull_points else "low",
+        "; ".join(bull_points) or "no strong affirmative signal beyond the baseline",
+    ))
+
+    # Bear: always argues against — names the weakest link on purpose.
+    weakest = []
+    if len(evidence) < 3:
+        weakest.append(f"only {len(evidence)} evidence item(s); demand is asserted, not shown")
+    if not any("paid" in m or "pay" in m for m in monetization):
+        weakest.append("no path implies anyone has agreed to pay")
+    weakest.append("willingness to pay is untested until a buyer commits value")
+    cases.append(_case("bear", "against",
+                       SEVERE if len(evidence) == 0 else "medium",
+                       "; ".join(weakest)))
+
+    # Fraud / manipulation: sybil-shaped evidence caps the verdict.
+    deduped = {e.strip().lower() for e in evidence if e and e.strip()}
+    sybil = len(evidence) >= 2 and len(deduped) < len(evidence)
+    thin_urgent = urgency == "high" and len(deduped) <= 1
+    if sybil or thin_urgent:
+        cases.append(_case(
+            "fraud_manipulation", "against", SEVERE,
+            ("evidence items are duplicated or near-identical — consistent with "
+             "manufactured demand" if sybil else
+             "high urgency asserted on a single evidence item — verify the "
+             "signal is organic before acting"),
+        ))
+    else:
+        cases.append(_case(
+            "fraud_manipulation", "neutral", "low",
+            "no sybil indicators in the evidence set; keep verifying provenance",
+        ))
+
+    # Incumbent response: who retaliates, and how cheaply?
+    cases.append(_case(
+        "incumbent_response", "against", "medium",
+        f"an incumbent with distribution can copy {offer} quickly; the durable "
+        "edge must be trust and cultural specificity, not the artifact itself",
+    ))
+
+    # Adoption friction: interest is not behavior change.
+    cases.append(_case(
+        "adoption_friction", "against",
+        "medium" if packet.get("buyer_type") == "consumer" else "low",
+        "audience interest does not imply workflow change; the smallest "
+        "validation action must measure behavior, not applause",
+    ))
+
+    # Do-nothing: the mandatory comparison.
+    cases.append(_case(
+        "do_nothing", "against", "low",
+        "skipping this preserves founder attention for a stronger signal; the "
+        "cost of waiting is one cycle of learning, not the market",
+    ))
+
+    # Opportunity cost: every yes is a no to something else.
+    cases.append(_case(
+        "opportunity_cost", "against",
+        "medium" if opportunity_score < 0.65 else "low",
+        f"score {opportunity_score} vs. alignment {market_alignment}: compare "
+        "against the best alternative use of the same attention and budget",
+    ))
+
+    return cases
+
+
+def severe_unresolved(cases: List[Dict[str, Any]]) -> List[str]:
+    """Names of severe, unresolved 'against' cases. A non-empty list caps
+    the verdict — a high score may not erase a severe unresolved risk."""
+    return [
+        c["case"] for c in cases
+        if c["stance"] == "against" and c["severity"] == SEVERE
+        and not c.get("resolved")
+    ]
+
+
+__all__ = ["build_cases", "severe_unresolved", "SEVERE"]

--- a/services/wealthmachine_client.py
+++ b/services/wealthmachine_client.py
@@ -99,10 +99,13 @@ class WealthMachineClient:
             recommended_next_action=str(payload.get("recommended_next_action") or ""),
             requires_human_approval=True,  # non-negotiable on this side
             reasons=list(payload.get("reasons") or []),
+            cases=list(payload.get("cases") or []),
         )
 
     def _evaluate_mock(self, packet: OpportunityPacket) -> VentureAssessment:
         """Deterministic local scoring with the same shape as the real engine."""
+        from services.adversarial_cases import build_cases, severe_unresolved
+
         score = 0.2
         score += 0.1 * min(len(packet.evidence), 3)
         score += {"high": 0.2, "medium": 0.1}.get(packet.urgency, 0.0)
@@ -114,6 +117,10 @@ class WealthMachineClient:
 
         legal_flags = _LEGAL_RISK_FLAGS & set(packet.risk_flags)
         finance = "finance_education_only" in packet.risk_flags
+
+        # Same adversarial committee as the real engine (mirrored module).
+        cases = build_cases(packet_to_wire(packet), score, round(min(0.9, score + 0.1), 3))
+        severe = severe_unresolved(cases)
 
         reasons = []
         if legal_flags:
@@ -129,6 +136,13 @@ class WealthMachineClient:
             go_no_go = "go"
             risk_level = "medium" if finance else "low"
             reasons.append(f"score {score} with offer and monetization paths")
+        if severe and go_no_go == "go":
+            # A high score may not erase a severe unresolved risk.
+            go_no_go = "needs_more_evidence"
+            reasons.append(f"severe unresolved adversarial case(s) cap the verdict: {severe}")
+        for case in cases:
+            if case["stance"] == "against" and case["severity"] != "low":
+                reasons.append(f"[{case['case']}] {case['argument']}")
         if finance:
             reasons.append("finance content must remain educational; no personalized advice")
 
@@ -153,6 +167,7 @@ class WealthMachineClient:
             recommended_next_action=validation_plan[0] if validation_plan else "gather evidence",
             requires_human_approval=True,
             reasons=reasons,
+            cases=cases,
         )
 
     # ------------------------------------------------------------------ #

--- a/tests/test_adversarial_mirror.py
+++ b/tests/test_adversarial_mirror.py
@@ -1,0 +1,75 @@
+"""The mock evaluator argues with itself exactly like the real engine:
+mirrored adversarial cases, preserved disagreement, and the rule that a
+high score may not erase a severe unresolved risk."""
+
+from db.models import OpportunityPacket
+from db.session import init_db
+from services.ledger import DecisionLedger
+from services.wealthmachine_client import WealthMachineClient
+
+
+def _client(tmp_path):
+    init_db()
+    return WealthMachineClient(ledger=DecisionLedger(path=str(tmp_path / "l.jsonl")))
+
+
+def test_strong_packet_gets_bear_and_do_nothing_cases(tmp_path):
+    client = _client(tmp_path)
+    strong = OpportunityPacket(
+        evidence=["five replies", "two DMs", "a collaboration ask"],
+        urgency="high", possible_offer="workshop",
+        monetization_paths=["paid workshop"],
+    )
+    assessment = client.evaluate(strong)
+    cases = {c["case"]: c for c in assessment.cases}
+
+    assert assessment.go_no_go == "go"
+    assert cases["bear"]["stance"] == "against"
+    assert cases["bull"]["stance"] == "for"  # disagreement preserved
+    assert "do_nothing" in cases and "opportunity_cost" in cases
+
+
+def test_sybil_evidence_caps_the_mock_verdict(tmp_path):
+    client = _client(tmp_path)
+    suspicious = OpportunityPacket(
+        evidence=["I'd pay for this!", "i'd pay for this!", "I'd pay for this! "],
+        urgency="high", possible_offer="course",
+        monetization_paths=["paid course"],
+    )
+    assessment = client.evaluate(suspicious)
+    cases = {c["case"]: c for c in assessment.cases}
+
+    assert cases["fraud_manipulation"]["severity"] == "high"
+    assert assessment.go_no_go != "go"
+    assert any("adversarial case" in r for r in assessment.reasons)
+    assert assessment.requires_human_approval is True
+
+
+def test_http_mode_passes_cases_through(tmp_path, monkeypatch):
+    import io
+    import json
+
+    monkeypatch.setenv("WEALTHMACHINE_URL", "http://wealthmachine.local")
+    client = _client(tmp_path)
+    packet = OpportunityPacket(evidence=["e1"], possible_offer="guide")
+
+    class _FakeResponse:
+        def __init__(self, payload):
+            self._body = io.BytesIO(json.dumps(payload).encode())
+
+        def __enter__(self):
+            return self._body
+
+        def __exit__(self, *exc):
+            return False
+
+    wire = {
+        "opportunity_packet_id": packet.id, "go_no_go": "defer",
+        "opportunity_score": 0.5, "requires_human_approval": True,
+        "cases": [{"case": "bear", "stance": "against", "severity": "medium",
+                   "argument": "willingness to pay untested", "resolved": False}],
+    }
+    monkeypatch.setattr("urllib.request.urlopen",
+                        lambda request, timeout=None: _FakeResponse(wire))
+    assessment = client.evaluate(packet)
+    assert assessment.cases and assessment.cases[0]["case"] == "bear"


### PR DESCRIPTION
## Summary

Companion to WealthMachineIntelligence Stage 4: `services/adversarial_cases.py` mirrors `src/services/adversarial.py` (documented as field-for-field compatible), so the offline mock evaluator presents the identical adversarial case structure as the real engine — bull/bear/fraud/incumbent/adoption-friction/do-nothing/opportunity-cost — with the same verdict-capping rule (severe unresolved "against" case caps `go` → `needs_more_evidence`). `VentureAssessment` gains a `cases` field; http mode and the push-receive endpoint pass remote cases through.

## Tests

3 new (`tests/test_adversarial_mirror.py`): strong packet keeps bear + do-nothing while still going; sybil evidence caps the mock verdict with `requires_human_approval` intact; http passthrough. Full suite **285 passed**; tsc clean.

## Rollback

Revert — additive only.

**Stacked on PR #51. Next: signed idempotent bridge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjuRe9SzeRJf5RMnPFzeRB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjuRe9SzeRJf5RMnPFzeRB)_