### PR TITLE
Phase 3: protocol swap — venture_protocol imports the kernel contracts module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ websockets==15.0.1
 pytest==8.3.3
 PyJWT==2.10.1
 prometheus-client==0.21.1
-# UNIIMENTE kernel SDK: governance primitives extracted from this repo
-# (kernel Phase 2). Pinned to the Phase 2 stack tip until kernel PRs
-# #11-#16 merge; switch the ref to @main once the stack lands.
-uniimente-kernel @ git+https://github.com/dababiyoda/uniimente-kernel.git@phase2/sdk-package-absorption#subdirectory=sdk-python
+# UNIIMENTE kernel SDK: governance primitives + signal wire contracts,
+# extracted/unified from this repo (kernel Phases 2-3). Pinned to the
+# Phase 3 stack tip until kernel PRs #11-#17 merge; switch to @main then.
+uniimente-kernel @ git+https://github.com/dababiyoda/uniimente-kernel.git@phase3/signal-contracts#subdirectory=sdk-python

--- a/services/venture_protocol.py
+++ b/services/venture_protocol.py
@@ -1,134 +1,43 @@
-"""The stable protocol between DALEOBANKS and WealthMachineIntelligence.
+"""Compatibility shim: the DALEOBANKS <-> WealthMachineIntelligence protocol.
 
-DALEOBANKS finds signals and builds public trust; WealthMachineIntelligence
-evaluates whether signals are business opportunities. The two systems stay
-separate and talk only through the wire contracts defined here:
-``OpportunityPacket`` out, ``VentureAssessment`` back, ``ValidationResult``
-recorded after the world responds. This module is designed to be copied
-verbatim into the WealthMachineIntelligence repo (or replaced by a shared
-package later) — keep it dependency-light and version every change.
+Unified in kernel Phase 3: the implementation now lives in the UNIIMENTE
+kernel SDK (``uniimente_kernel.contracts``), one module both repos import
+instead of keeping mirrored copies in sync. The wire is formalized as
+kernel contracts ``venture-signal`` and ``signal-assessment`` (v1.1,
+byte-compatible with what this organ already emits). One behavioral note:
+``validate_assessment_wire`` now also rejects assessments whose
+``requires_human_approval`` is not exactly True — the rule WMI already
+enforced on its side, applied on receipt here. WMI assessments always
+carry it True.
 
-The core rule: the machine prepares, the human authorizes, the world
-responds, the system learns. Nothing in this protocol executes anything.
+The core rule stands: the machine prepares, the human authorizes, the
+world responds, the system learns. Nothing in this protocol executes
+anything.
 """
 
-from __future__ import annotations
-
-from dataclasses import asdict
-from typing import Any, Dict
-
-SCHEMA_VERSION = "1.1"
-
-ALLOWED_SIGNAL_TYPES = frozenset({
-    "social_complaint",
-    "news_trend",
-    "regulatory_shift",
-    "audience_reaction",
-    "repeated_question",
-    "relationship_signal",
-    "content_opportunity",
-    "product_opportunity",
-    "partnership_opportunity",
-    "operator_thought",
-})
-
-ALLOWED_GO_NO_GO = frozenset({"go", "defer", "kill", "needs_more_evidence"})
-
-# ValidationResult contract: outcomes the world can hand back. Negative
-# (no response) is a legitimate, recorded outcome — never an absence.
-ALLOWED_RESULT_CLASSIFICATIONS = frozenset({
-    "success", "failure", "mixed", "inconclusive", "negative",
-})
-
-# Evidence tiers, strongest first. Payment outranks commitment outranks
-# conversation outranks engagement outranks passive observation.
-ALLOWED_EVIDENCE_TIERS = frozenset({
-    "payment", "commitment", "conversation", "engagement", "observation",
-})
-
-ALLOWED_IDENTITY_TYPES = frozenset({
-    "main_identity",
-    "brand_account",
-    "project_account",
-    "pseudonymous_brand",
-    "faceless_media_page",
-    "company_page",
-})
-
-FORBIDDEN_IDENTITY_TYPES = frozenset({
-    "fake_person",
-    "impersonation",
-    "fake_expert_identity",
-    "ban_evasion_account",
-    "engagement_manipulation_account",
-})
-
-# Hardcoded, non-configurable media-company policy. These are not settings.
-LANE_POLICY = (
-    "No account may be used to simulate independent public support for another account.",
-    "No fake consensus.",
-    "No coordinated inauthentic amplification.",
-    "No auto-DMs at scale.",
-    "No impersonation.",
-    "No undisclosed sponsorships.",
-    "No stolen media.",
-    "No guaranteed financial claims.",
-    "No personalized legal or financial advice unless reviewed by a qualified professional.",
-    "Every account lane must have a distinct purpose, audience, and content policy.",
+from uniimente_kernel.contracts import (
+    ALLOWED_EVIDENCE_TIERS,
+    ALLOWED_GO_NO_GO,
+    ALLOWED_IDENTITY_TYPES,
+    ALLOWED_RESULT_CLASSIFICATIONS,
+    ALLOWED_SIGNAL_TYPES,
+    FINANCE_EDUCATION_FLAG,
+    FORBIDDEN_IDENTITY_TYPES,
+    LANE_POLICY,
+    LEGAL_RISK_FLAGS,
+    SCHEMA_VERSION,
+    assessment_to_wire,
+    packet_to_wire,
+    validate_assessment_wire,
+    validate_identity_type,
+    validate_packet_wire,
 )
-
-
-def packet_to_wire(packet: Any) -> Dict[str, Any]:
-    """Serialize an OpportunityPacket for transport (JSON-safe)."""
-    payload = asdict(packet)
-    payload["schema_version"] = SCHEMA_VERSION
-    payload["created_at"] = packet.created_at.isoformat()
-    return payload
-
-
-def assessment_to_wire(assessment: Any) -> Dict[str, Any]:
-    payload = asdict(assessment)
-    payload["schema_version"] = SCHEMA_VERSION
-    payload["created_at"] = assessment.created_at.isoformat()
-    return payload
-
-
-def validate_assessment_wire(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Validate an inbound VentureAssessment payload. Raises ValueError on a
-    contract violation — inbound wire data is untrusted input."""
-    if not isinstance(payload, dict):
-        raise ValueError("assessment payload must be an object")
-    go_no_go = payload.get("go_no_go")
-    if go_no_go not in ALLOWED_GO_NO_GO:
-        raise ValueError(f"go_no_go must be one of {sorted(ALLOWED_GO_NO_GO)}")
-    if not payload.get("opportunity_packet_id"):
-        raise ValueError("opportunity_packet_id is required")
-    score = payload.get("opportunity_score")
-    if score is not None and not (0.0 <= float(score) <= 1.0):
-        raise ValueError("opportunity_score must be within [0, 1]")
-    return payload
-
-
-def validate_identity_type(identity_type: str) -> str:
-    """The load-bearing gate for account lanes: authentic lanes only."""
-    if identity_type in FORBIDDEN_IDENTITY_TYPES:
-        raise ValueError(
-            f"identity_type '{identity_type}' is forbidden: account lanes are "
-            "brands and projects, never fake people, impersonation, or "
-            "engagement manipulation"
-        )
-    if identity_type not in ALLOWED_IDENTITY_TYPES:
-        raise ValueError(
-            f"identity_type '{identity_type}' is not recognized; allowed: "
-            f"{sorted(ALLOWED_IDENTITY_TYPES)}"
-        )
-    return identity_type
-
 
 __all__ = [
     "SCHEMA_VERSION", "ALLOWED_SIGNAL_TYPES", "ALLOWED_GO_NO_GO",
     "ALLOWED_RESULT_CLASSIFICATIONS", "ALLOWED_EVIDENCE_TIERS",
     "ALLOWED_IDENTITY_TYPES", "FORBIDDEN_IDENTITY_TYPES", "LANE_POLICY",
+    "LEGAL_RISK_FLAGS", "FINANCE_EDUCATION_FLAG",
     "packet_to_wire", "assessment_to_wire", "validate_assessment_wire",
-    "validate_identity_type",
+    "validate_identity_type", "validate_packet_wire",
 ]


### PR DESCRIPTION
## What

Phase 3, organ side: the mirrored protocol module is deleted as an implementation and becomes a re-export shim over `uniimente_kernel.contracts` (kernel PR #17). One module now defines the DALEOBANKS ↔ WMI wire for both repos.

## Changes

- `services/venture_protocol.py` → shim re-exporting the kernel contracts module: `SCHEMA_VERSION`, all enums (signal types, go/no-go, result classifications, evidence tiers, identity types), `LANE_POLICY`, `LEGAL_RISK_FLAGS`, `FINANCE_EDUCATION_FLAG`, `packet_to_wire`, `assessment_to_wire`, `validate_packet_wire`, `validate_assessment_wire`, `validate_identity_type`.
- `requirements.txt` → kernel pin moves to the Phase 3 branch (`phase3/signal-contracts`, SDK v0.5.0).

## One deliberate behavior change (documented)

`validate_assessment_wire` now rejects any assessment whose `requires_human_approval` is not exactly `True` — the rule WMI already enforced on its side of the wire, now applied on receipt here. Real WMI assessments always carry it `True`, so the running bridge is unaffected; the only caller that could notice is a synthetic fixture asserting the old, weaker check.

## Verification

```
services.venture_protocol import surface — OK
packet_to_wire adds schema_version 1.1 + ISO created_at — OK
validate_assessment_wire: valid passes; requires_human_approval=False rejected — OK
validate_identity_type + LANE_POLICY (10 rules) — OK
(kernel side: 94/94 incl. 18 contract tests with the FIRE fixture both repos test against)
```

## Merge order

1. Kernel PRs #11 → #17 (founder)
2. DALEOBANKS #58 → #59 (swaps 1/2, 2/2A)
3. This PR + WMI protocol swap PR (sister PR on WealthMachineIntelligence)

Proposal only — merge remains founder authority.