### PR TITLE
Phase 1 organ side: publishing family routed through the ConsequenceGate

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ websockets==15.0.1
 pytest==8.3.3
 PyJWT==2.10.1
 prometheus-client==0.21.1
-# UNIIMENTE kernel SDK: governance primitives + signal wire contracts,
-# extracted/unified from this repo (kernel Phases 2-3). Pinned to the
-# Phase 3 stack tip until kernel PRs #11-#17 merge; switch to @main then.
-uniimente-kernel @ git+https://github.com/dababiyoda/uniimente-kernel.git@phase3/signal-contracts#subdirectory=sdk-python
+# UNIIMENTE kernel SDK: governance primitives, signal wire contracts,
+# and the ConsequenceGate (kernel Phases 2-5). Pinned to the Phase 5
+# stack tip until kernel PRs #11-#22 merge; switch to @main then.
+uniimente-kernel @ git+https://github.com/dababiyoda/uniimente-kernel.git@phase5/consequence-gate#subdirectory=sdk-python

--- a/services/gate.py
+++ b/services/gate.py
@@ -1,0 +1,227 @@
+"""Consequence Gate wiring for the organ's publishing action family.
+
+Every live outbound post crosses the kernel ConsequenceGate:
+
+    evidence -> authority (capability grant) -> commit witness
+    -> one-time execution -> receipt -> postcondition -> reconciliation
+    -> outcome
+
+The boundary is total: ``publish_post`` sends *every* attempt through
+``gate.execute``, including attempts with no grant (which the gate
+rejects and ledgers). A rejection fails toward silence: the caller
+receives a dry-run result, exactly as it does for a disarmed kill
+switch. There is no unmediated live path in this family.
+
+Authority posture: grants mint only from verified operator approvals.
+The approval verifier is injected at ``configure`` time (app startup
+wires it to the operator line); the lazy default denies everything,
+so an unconfigured organ is a silent organ, never an open one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import threading
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from uniimente_kernel.capability import (
+    CapabilityService,
+    GrantRecord,
+    InMemoryGrantStore,
+)
+from uniimente_kernel.commit_witness import CommitWitness
+from uniimente_kernel.events import EventSpine
+from uniimente_kernel.gate import ConsequenceGate
+
+from services.ledger import get_kill_switch, get_ledger
+from services.logging_utils import get_logger
+from services.social_base import SocialPostResult
+
+logger = get_logger(__name__)
+
+ORG = "spiffe://uniimente.internal/organ/daleobanks"
+AGENT = ORG + "/agent/publisher"
+LEGAL_PRINCIPAL = "alfonso-lopez"
+POLICY_VERSION = "1.0.0"
+
+_grant_store: Optional[InMemoryGrantStore] = None
+_capability: Optional[CapabilityService] = None
+_gate: Optional[ConsequenceGate] = None
+# Active grant per (platform, kind): the organ's publishing authority
+# registry. Minting a grant for a pair replaces the previous entry.
+_active_grants: Dict[Tuple[str, str], str] = {}
+
+
+def configure(
+    *,
+    approval_verifier: Callable[[str], bool],
+    grant_store: Optional[InMemoryGrantStore] = None,
+) -> ConsequenceGate:
+    """Wire the gate over the organ's shared ledger and kill switch.
+
+    ``approval_verifier`` decides whether an approval request id
+    represents a verified operator approval; grants mint only behind it.
+    """
+    global _grant_store, _capability, _gate
+    ledger = get_ledger()
+    _grant_store = grant_store or InMemoryGrantStore()
+    _capability = CapabilityService(
+        _grant_store, ledger, approval_verifier=approval_verifier,
+    )
+    spine = EventSpine(
+        ledger, source=ORG, actor=AGENT,
+        legal_principal=LEGAL_PRINCIPAL, policy_version=POLICY_VERSION,
+    )
+    witness = CommitWitness(ledger, kill_switch=get_kill_switch())
+    _gate = ConsequenceGate(
+        ledger, capability=_capability, witness=witness, spine=spine,
+    )
+    return _gate
+
+
+def get_gate() -> ConsequenceGate:
+    """The organ's gate. Unconfigured means deny-all, never unmediated."""
+    global _gate
+    if _gate is None:
+        logger.warning("gate used before configure(); defaulting to deny-all")
+        configure(approval_verifier=lambda request_id: False)
+    return _gate
+
+
+def reset_gate() -> None:
+    """Drop gate state (tests). Shared ledger/switch reset separately."""
+    global _grant_store, _capability, _gate
+    _grant_store = None
+    _capability = None
+    _gate = None
+    _active_grants.clear()
+
+
+def mint_publish_grant(
+    *,
+    platform: str,
+    kind: str = "post",
+    approval_request_id: str,
+    maximum_uses: int = 30,
+    objective: Optional[str] = None,
+) -> GrantRecord:
+    """Mint and register the active publishing grant for (platform, kind).
+
+    Raises CapabilityError if the approval does not verify. Authority
+    starts narrow: one platform, one kind, bounded uses, shadow stage.
+    """
+    if _capability is None:
+        get_gate()
+    grant = GrantRecord(
+        grantee=AGENT,
+        granted_by=LEGAL_PRINCIPAL,
+        legal_actor=LEGAL_PRINCIPAL,
+        objective=objective or f"publish {kind} on {platform}",
+        permitted_actions=[f"publish.{kind}"],
+        resource=platform,
+        maximum_uses=maximum_uses,
+        initial_stage="shadow",
+    )
+    minted = _capability.mint(grant, approval_request_id=approval_request_id)
+    _active_grants[(platform, kind)] = minted.grant_id
+    return minted
+
+
+def _await_in_thread(coro: Any) -> Any:
+    """Run one coroutine on a fresh loop in a worker thread.
+
+    The Commit Witness executes synchronously; the platform adapters are
+    async. A dedicated thread with its own loop keeps one-time-execution
+    semantics without nesting loops in the caller's thread.
+    """
+    box: Dict[str, Any] = {}
+
+    def runner() -> None:
+        try:
+            box["result"] = asyncio.run(coro)
+        except Exception as exc:  # noqa: BLE001 - re-raised in caller thread
+            box["error"] = exc
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    thread.join()
+    if "error" in box:
+        raise box["error"]
+    return box.get("result")
+
+
+def _live_receipt(result: Dict[str, Any]) -> bool:
+    return bool(result.get("post_id")) and result.get("dry_run") is False
+
+
+async def publish_post(
+    *,
+    platform: str,
+    kind: str,
+    content: str,
+    impl: Callable[..., Any],
+    impl_kwargs: Dict[str, Any],
+    dry_run: Callable[..., Any],
+    metadata: Optional[Dict[str, Any]] = None,
+) -> SocialPostResult:
+    """Mediate one publish attempt through the ConsequenceGate.
+
+    ``impl`` is the adapter's ``_publish_impl``; ``dry_run`` its
+    ``_dry_run``. The witness never sees the platform client: the
+    executor reduces the coroutine to a JSON-safe receipt dict, and the
+    returned ``SocialPostResult`` is rebuilt from it.
+    """
+    gate = get_gate()
+    grant_id = _active_grants.get((platform, kind), "none")
+    content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    parameters = {
+        "content_sha256": content_hash,
+        "in_reply_to": impl_kwargs.get("in_reply_to"),
+        "quote_to": impl_kwargs.get("quote_to"),
+    }
+
+    def executor() -> Dict[str, Any]:
+        result = _await_in_thread(impl(**impl_kwargs))
+        return {
+            "platform": result.platform,
+            "post_id": result.post_id,
+            "dry_run": result.dry_run,
+        }
+
+    outcome = gate.execute(
+        grant_id=grant_id,
+        action_type=f"publish.{kind}",
+        resource=platform,
+        parameters=parameters,
+        executor=executor,
+        postconditions={"live_receipt": _live_receipt},
+        expected_consequence=f"{kind} live on {platform}",
+        subject=f"{platform}:{kind}",
+    )
+
+    if outcome.status in ("committed", "deduplicated") and outcome.receipt is not None:
+        receipt = outcome.receipt.result or {}
+        return SocialPostResult(
+            platform=receipt.get("platform", platform),
+            post_id=receipt.get("post_id", ""),
+            dry_run=bool(receipt.get("dry_run", False)),
+            meta=metadata,
+        )
+
+    # rejected | failed | postcondition_failed: fail toward silence.
+    # The gate has already ledgered and chained the honest record.
+    logger.warning(
+        "publish %s on %s not committed (status=%s); returning dry run",
+        kind, platform, outcome.status,
+    )
+    return await dry_run(kind=kind, metadata=metadata)
+
+
+__all__ = [
+    "configure",
+    "get_gate",
+    "reset_gate",
+    "mint_publish_grant",
+    "publish_post",
+]

--- a/services/social_base.py
+++ b/services/social_base.py
@@ -1,10 +1,14 @@
 """Common utilities for multi-platform social clients.
 
 ``BaseSocialClient.publish`` is a template method: it runs the safety gate
-(ledger record, kill switch, rate governor) and then delegates to the
-subclass's ``_publish_impl``. Any new platform adapter is therefore logged,
-kill-switched, and rate-governed the moment it inherits the base class —
-safety is inherited, never re-implemented.
+(ledger record, kill switch, rate governor) and then delegates the live
+path to the ConsequenceGate (``services.gate.publish_post``), which
+executes the subclass's ``_publish_impl`` exactly once per authorized
+action fingerprint. Any new platform adapter is therefore logged,
+kill-switched, rate-governed, authority-checked, witnessed, and receipted
+the moment it inherits the base class — safety is inherited, never
+re-implemented. A live publish without a valid capability grant fails
+toward silence (dry run); there is no unmediated live path.
 """
 
 from __future__ import annotations
@@ -60,7 +64,7 @@ class BaseSocialClient:
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SocialPostResult:
         """Gated publish: ledger every attempt, honor the kill switch and
-        rate governor, then delegate to the platform's ``_publish_impl``."""
+        rate governor, then cross the ConsequenceGate for the live path."""
 
         ledger = get_ledger()
         ledger.record(
@@ -86,12 +90,22 @@ class BaseSocialClient:
             logger.warning("Rate governor blocked live %s on %s", kind, self.platform)
             result = await self._dry_run(kind=kind, metadata=metadata)
         else:
-            result = await self._publish_impl(
-                content=content,
+            from services.gate import publish_post
+
+            result = await publish_post(
+                platform=self.platform,
                 kind=kind,
-                in_reply_to=in_reply_to,
-                quote_to=quote_to,
-                intensity=intensity,
+                content=content,
+                impl=self._publish_impl,
+                impl_kwargs={
+                    "content": content,
+                    "kind": kind,
+                    "in_reply_to": in_reply_to,
+                    "quote_to": quote_to,
+                    "intensity": intensity,
+                    "metadata": metadata,
+                },
+                dry_run=self._dry_run,
                 metadata=metadata,
             )
 

--- a/tests/test_gate_publishing.py
+++ b/tests/test_gate_publishing.py
@@ -1,0 +1,181 @@
+"""ConsequenceGate adoption: the publishing family is 100% mediated.
+
+Every live outbound post crosses evidence -> authority -> commit witness
+-> execution -> receipt -> reconciliation. These tests pin the full
+chain, the replay defense, the fail-closed rejection paths, and the
+disarm-on-divergence doctrine.
+"""
+
+import pytest
+
+from config import get_config, update_config
+from services import gate as gate_service
+from services.ledger import (
+    DecisionLedger,
+    KillSwitch,
+    RateGovernor,
+    set_shared_instances,
+    reset_shared_instances,
+)
+from services.social_base import BaseSocialClient, SocialPostResult
+
+
+class LiveClient(BaseSocialClient):
+    platform = "testnet"
+
+    def __init__(self, *, post_id="live_1", fail=None):
+        super().__init__(enabled=True, live=True)
+        self.post_id = post_id
+        self.fail = fail
+        self.calls = []
+
+    async def _publish_impl(self, *, content, kind="post", in_reply_to=None,
+                            quote_to=None, intensity=1, metadata=None):
+        self.calls.append(content)
+        if self.fail == "raise":
+            raise RuntimeError("provider down")
+        if self.fail == "fake_dry":
+            # Provider pretended success but returned no live receipt.
+            return SocialPostResult(platform=self.platform, post_id="", dry_run=True)
+        return SocialPostResult(platform=self.platform, post_id=self.post_id,
+                                dry_run=False, meta=metadata)
+
+
+@pytest.fixture
+def env(tmp_path):
+    ledger = DecisionLedger(path=str(tmp_path / "ledger.jsonl"))
+    set_shared_instances(
+        ledger=ledger,
+        kill_switch=KillSwitch(ledger=ledger),
+        governor=RateGovernor(max_actions=100, window_seconds=3600),
+    )
+    gate_service.configure(approval_verifier=lambda request_id: True)
+    previous_live = get_config().LIVE
+    update_config(LIVE=True)
+    yield ledger
+    update_config(LIVE=previous_live)
+    gate_service.reset_gate()
+    reset_shared_instances()
+
+
+def _events(ledger):
+    return [e["event"] for e in ledger.replay()]
+
+
+async def test_live_publish_closes_the_full_chain(env):
+    gate_service.mint_publish_grant(platform="testnet", approval_request_id="a1")
+    client = LiveClient(post_id="live_9")
+
+    result = await client.publish(content="hello world", kind="post")
+
+    assert result.dry_run is False
+    assert result.post_id == "live_9"
+    assert client.calls == ["hello world"]
+
+    events = _events(env)
+    for expected in ("consequence.requested", "consequence.authorized",
+                     "consequence.committed"):
+        assert expected in events
+    # Causal chain replays request -> authorized -> committed in order.
+    committed = env.replay("consequence.committed")[-1]["payload"]
+    chain = [e["type"] for e in gate_service.get_gate().spine.causal_chain(committed["id"])]
+    assert chain == ["consequence.requested", "consequence.authorized",
+                     "consequence.committed"]
+    # Exactly one grant use consumed.
+    grant_id = gate_service._active_grants[("testnet", "post")]
+    gate = gate_service.get_gate()
+    assert gate.capability.store.get(grant_id).uses_consumed == 1
+    ok, bad = env.verify_chain()
+    assert ok is True and bad is None
+
+
+async def test_retried_publish_never_double_posts(env):
+    gate_service.mint_publish_grant(platform="testnet", approval_request_id="a1")
+    client = LiveClient()
+
+    first = await client.publish(content="same text", kind="post")
+    second = await client.publish(content="same text", kind="post")
+
+    assert first.dry_run is False
+    assert second.dry_run is False
+    assert second.post_id == first.post_id  # idempotent read-back
+    assert client.calls == ["same text"]  # provider saw exactly one call
+
+    assert "consequence.deduplicated" in _events(env)
+    grant_id = gate_service._active_grants[("testnet", "post")]
+    gate = gate_service.get_gate()
+    assert gate.capability.store.get(grant_id).uses_consumed == 1
+
+
+async def test_different_content_is_a_new_action(env):
+    gate_service.mint_publish_grant(platform="testnet", approval_request_id="a1")
+    client = LiveClient()
+
+    await client.publish(content="text a", kind="post")
+    await client.publish(content="text b", kind="post")
+
+    assert client.calls == ["text a", "text b"]
+
+
+async def test_unapproved_platform_fails_closed(env):
+    # No grant minted for (testnet, post): authority refuses, no execution.
+    client = LiveClient()
+
+    result = await client.publish(content="hello", kind="post")
+
+    assert result.dry_run is True
+    assert client.calls == []
+    assert "consequence.rejected" in _events(env)
+    assert "commit_witnessed" not in _events(env)
+
+
+async def test_unverified_approval_mints_nothing(env):
+    gate_service.reset_gate()
+    gate_service.configure(approval_verifier=lambda request_id: False)
+
+    from uniimente_kernel.capability import CapabilityError
+    with pytest.raises(CapabilityError):
+        gate_service.mint_publish_grant(platform="testnet",
+                                        approval_request_id="forged")
+
+    client = LiveClient()
+    result = await client.publish(content="hello", kind="post")
+    assert result.dry_run is True
+    assert client.calls == []
+
+
+async def test_provider_failure_receipted_and_retryable(env):
+    gate_service.mint_publish_grant(platform="testnet", approval_request_id="a1")
+    client = LiveClient(fail="raise")
+
+    first = await client.publish(content="hello", kind="post")
+    assert first.dry_run is True  # failed toward silence
+    assert "consequence.failed" in _events(env)
+
+    client.fail = None  # provider repaired
+    second = await client.publish(content="hello", kind="post")
+    assert second.dry_run is False
+    assert client.calls == ["hello", "hello"]  # retry executed, not deduped
+
+
+async def test_fake_success_disarms_the_organ(env):
+    gate_service.mint_publish_grant(platform="testnet", approval_request_id="a1")
+    client = LiveClient(fail="fake_dry")
+
+    result = await client.publish(content="hello", kind="post")
+
+    assert result.dry_run is True
+    # Postcondition failed: reconciliation opened and the organ went silent.
+    assert "reconciliation_opened" in _events(env)
+    assert "consequence.reconciliation_opened" in _events(env)
+    assert get_config().LIVE is False
+
+    # The attempt is recorded as executed-but-unverified; after the
+    # operator repairs and re-arms, a restarted gate must not blindly
+    # re-execute the same fingerprint.
+    update_config(LIVE=True)
+    gate_service.configure(approval_verifier=lambda request_id: True)
+    client2 = LiveClient()
+    again = await client2.publish(content="hello", kind="post")
+    assert client2.calls == []
+    assert "consequence.deduplicated" in _events(env)

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -9,6 +9,13 @@ import pytest
 
 from config import get_config
 from services import gate as gate_service
+from services.ledger import (
+    DecisionLedger,
+    KillSwitch,
+    RateGovernor,
+    set_shared_instances,
+    reset_shared_instances,
+)
 from services.multiplexer import SocialMultiplexer
 from services.linkedin_client import LinkedInClient
 from services.mastodon_client import MastodonClient
@@ -67,10 +74,20 @@ class MediaStubXClient:
 
 
 @pytest.mark.asyncio
-async def test_multiplexer_uploads_media_before_post(monkeypatch):
+async def test_multiplexer_uploads_media_before_post(monkeypatch, tmp_path):
     config = get_config()
     previous_live = config.LIVE
     config.LIVE = True
+
+    # Isolate the shared safety state: the witness dedupes across restarts,
+    # so a test that commits to the on-disk default ledger would poison
+    # later runs of this same test.
+    ledger = DecisionLedger(path=str(tmp_path / "ledger.jsonl"))
+    set_shared_instances(
+        ledger=ledger,
+        kill_switch=KillSwitch(ledger=ledger),
+        governor=RateGovernor(max_actions=100, window_seconds=3600),
+    )
 
     # ConsequenceGate posture: the live path requires a publish grant.
     gate_service.configure(approval_verifier=lambda request_id: True)
@@ -96,6 +113,7 @@ async def test_multiplexer_uploads_media_before_post(monkeypatch):
 
     config.LIVE = previous_live
     gate_service.reset_gate()
+    reset_shared_instances()
 
     assert x_client.uploads == [("sample.png", "image")]
     assert x_client.tweets[0]["media_ids"] == ["media123"]

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -8,6 +8,7 @@ sys.modules.setdefault("tweepy", types.SimpleNamespace(TooManyRequests=Exception
 import pytest
 
 from config import get_config
+from services import gate as gate_service
 from services.multiplexer import SocialMultiplexer
 from services.linkedin_client import LinkedInClient
 from services.mastodon_client import MastodonClient
@@ -71,6 +72,10 @@ async def test_multiplexer_uploads_media_before_post(monkeypatch):
     previous_live = config.LIVE
     config.LIVE = True
 
+    # ConsequenceGate posture: the live path requires a publish grant.
+    gate_service.configure(approval_verifier=lambda request_id: True)
+    gate_service.mint_publish_grant(platform="x", approval_request_id="a1")
+
     x_client = MediaStubXClient()
 
     multiplexer = SocialMultiplexer(
@@ -90,6 +95,7 @@ async def test_multiplexer_uploads_media_before_post(monkeypatch):
     )
 
     config.LIVE = previous_live
+    gate_service.reset_gate()
 
     assert x_client.uploads == [("sample.png", "image")]
     assert x_client.tweets[0]["media_ids"] == ["media123"]

--- a/tests/test_social_gate.py
+++ b/tests/test_social_gate.py
@@ -1,8 +1,14 @@
-"""Tests for the inherited publish gate in BaseSocialClient."""
+"""Tests for the inherited publish gate in BaseSocialClient.
+
+Authority posture (since the ConsequenceGate adoption): a live publish
+requires a valid capability grant for (platform, kind). Tests mint that
+grant in the fixture; one test pins the no-grant rejection path.
+"""
 
 import pytest
 
 from config import get_config, update_config
+from services import gate as gate_service
 from services.ledger import (
     DecisionLedger,
     KillSwitch,
@@ -30,7 +36,8 @@ class RecordingClient(BaseSocialClient):
 
 @pytest.fixture
 def gate(tmp_path):
-    """Isolated ledger/kill-switch/governor wired into the shared gate."""
+    """Isolated ledger/kill-switch/governor wired into the shared gate,
+    plus a configured ConsequenceGate with a testnet publish grant."""
     ledger = DecisionLedger(path=str(tmp_path / "ledger.jsonl"))
     governor = RateGovernor(max_actions=2, window_seconds=3600)
     set_shared_instances(
@@ -38,9 +45,14 @@ def gate(tmp_path):
         kill_switch=KillSwitch(ledger=ledger),
         governor=governor,
     )
+    gate_service.configure(approval_verifier=lambda request_id: True)
+    gate_service.mint_publish_grant(
+        platform="testnet", approval_request_id="a1", maximum_uses=100,
+    )
     previous_live = get_config().LIVE
     yield ledger
     update_config(LIVE=previous_live)
+    gate_service.reset_gate()
     reset_shared_instances()
 
 
@@ -70,6 +82,21 @@ async def test_armed_switch_delegates_to_impl(gate):
 
     results = gate.replay("publish_result")
     assert results[-1]["payload"]["dry_run"] is False
+
+
+async def test_armed_switch_without_grant_fails_to_dry_run(gate):
+    update_config(LIVE=True)
+    gate_service.reset_gate()  # unconfigured: deny-all, never unmediated
+    client = RecordingClient()
+
+    result = await client.publish(content="hello", kind="post")
+
+    assert result.dry_run is True
+    assert client.impl_calls == 0
+
+    events = [e["event"] for e in gate.replay()]
+    assert "consequence.requested" in events
+    assert "consequence.rejected" in events
 
 
 async def test_rate_governor_gates_excess_publishes(gate):


### PR DESCRIPTION
## The first evidence threshold: 100% Verified Mediated Side-Effect Coverage

Stacked on #60. This is the organ half of Phase 1. Kernel PR #22 built the gate; this PR puts the organ's one bounded external action family — **outbound social posts** — entirely behind it:

**Evidence → Policy → Authority → Commit Witness → Execution → Receipt → Reconciliation → Outcome**

### Bypass analysis (the "100%" claim, scoped honestly)

Searched the repo for every path that produces an external post:

- `create_tweet` is called only inside `_XAdapter._publish_impl` — inside the seam. No direct callers outside tests.
- `multiplexer.publish` has exactly two production callers: `runner.py`'s post job and `crisis.py`'s calming message. Both route through `BaseSocialClient.publish`.
- `BaseSocialClient.publish` is the single template method every platform adapter inherits (x, linkedin, mastodon, and any future adapter).

**Family boundary**: outbound posts via the multiplexer. DMs, likes, follows, and bookmarks (`XClient._execute_write`) are *separate action families*, deliberately out of scope for this threshold; they are the next families to gate (same pattern, one PR each).

### What changes

**`services/gate.py` (new)** — organ wiring of the kernel `ConsequenceGate`:
- `configure(approval_verifier=…)` composes capability service + commit witness (on the organ kill switch) + event spine over the shared organ ledger. The lazy default is **deny-all**: an unconfigured organ is silent, never open.
- `mint_publish_grant(platform, kind, approval_request_id, …)` — grants mint only behind a verified operator approval; forged approvals raise. Authority starts narrow: one platform, one kind, bounded uses, shadow stage.
- `publish_post(...)` mediates every attempt: content-hash fingerprint (raw content never touches the ledger), JSON-safe receipts, `live_receipt` postcondition — a provider reporting fake success **disarms the organ** and opens reconciliation.

**`services/social_base.py`** — the live branch delegates to `gate.publish_post` instead of calling `_publish_impl` directly. Kill switch and rate governor remain as outer layers (defense in depth). No grant → rejection → dry run, the same fail-toward-silence posture as a disarmed switch.

**`requirements.txt`** — kernel pin moves to `phase5/consequence-gate` (SDK v0.8.0).

### Adversarial coverage (harness: 39/39 green = 25 prior + 14 new/updated)

- full chain: `consequence.requested → authorized → committed`, causal chain replays in order, exactly one grant use consumed, ledger chain verifies
- replay defense: retried identical post **never double-posts**, dedupe burns no grant use, idempotent read-back of the original post id
- fail-closed: no grant → dry run + `consequence.rejected`, executor never ran; forged approval → mint raises
- provider failure → `consequence.failed` + dry run; repaired provider → retry executes (failures never deduplicated)
- fake success (empty post id) → postcondition fails → reconciliation opens + **organ disarms globally**; after repair and re-arm, a restarted gate deduplicates the unverified attempt instead of blindly re-executing
- `test_social_gate.py` updated to the grant posture (one behavior change, intended: armed + live now also requires a grant); `test_multiplexer.py` media test mints its grant

### Known limitations (documented, not hidden)

- Grant registry is in-process; on restart the organ defaults to deny-all until the operator re-mints. Persistent grant storage arrives with the ORM↔contract bridge (Phase 3 tail, noted in #59).
- App startup wiring of `configure(approval_verifier=operator_line…)` lands with that same bridge; until then the organ fails closed, which is the correct default.
- Outcome observation (24h engagement check) uses `gate.record_outcome`; the runner-side scheduled outcome pull is the follow-up package.

### Handoff

Kernel stack through #22 + organ stack through this PR = **Phase 1 closed for one bounded action family** at the code level. The external proof — one real post executed, receipted, and reconciled through the gate — requires live platform credentials and a live approval, which are founder-side inputs. Next build target per the plan: Phase 2, First Evolution Cycle (ClosureLoop, StrategyTree, SpiderWebAudit, ExperimentSpec, EvolutionCapsule, VerifierRecord, RetainRegressKillDecision).