### PR TITLE
Bind capability grants to the approved intent's declared scope

### DIFF
--- a/services/capability.py
+++ b/services/capability.py
@@ -31,6 +31,34 @@ def _now() -> datetime:
     return datetime.now(UTC)
 
 
+_SCOPE_RESOURCE_KEYS = (
+    "resource", "resources", "draft_id", "draft_ids",
+    "opportunity_packet_id", "venture_assessment_id", "target", "targets",
+)
+
+
+def _approved_scope(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """The narrowing scope an ApprovalRequest's payload declares."""
+    resources: set = set()
+    for key in _SCOPE_RESOURCE_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            resources.add(value)
+        elif isinstance(value, list):
+            resources.update(v for v in value if isinstance(v, str) and v)
+    max_cost = payload.get("max_cost")
+    try:
+        max_cost = float(max_cost) if max_cost is not None else None
+    except (TypeError, ValueError):
+        max_cost = None
+    action_type = payload.get("action_type")
+    return {
+        "resources": resources,
+        "max_cost": max_cost,
+        "action_type": action_type if isinstance(action_type, str) and action_type else None,
+    }
+
+
 def default_ttl_hours() -> int:
     try:
         return int(os.getenv("CAPABILITY_TTL_HOURS", "72"))
@@ -80,6 +108,29 @@ class CapabilityService:
             )
         if not action_type or not resource:
             raise CapabilityError("action_type and resource are required")
+
+        # A grant may NARROW the approved intent, never broaden it. When the
+        # approval's payload names resources, the grant must target one of
+        # them; a declared cost ceiling caps the grant; a declared action
+        # type must match. A payload with no scope fields imposes no
+        # narrowing (legacy operator approvals).
+        scope = _approved_scope(approval.payload or {})
+        if scope["resources"] and resource not in scope["resources"]:
+            self._reject("(unminted)", "resource_outside_approved_intent")
+            raise CapabilityError(
+                "grant must narrow the approved intent — resource "
+                f"'{resource}' was not named in the approval"
+            )
+        if scope["action_type"] and action_type != scope["action_type"]:
+            self._reject("(unminted)", "action_outside_approved_intent")
+            raise CapabilityError(
+                f"approved intent authorizes '{scope['action_type']}', not '{action_type}'"
+            )
+        if scope["max_cost"] is not None and float(max_cost) > scope["max_cost"]:
+            self._reject("(unminted)", "cost_above_approved_intent")
+            raise CapabilityError(
+                f"grant cost {max_cost} exceeds the approved ceiling {scope['max_cost']}"
+            )
 
         grant = CapabilityGrant(
             requester_identity=requester_identity,

--- a/tests/test_capability_grants.py
+++ b/tests/test_capability_grants.py
@@ -107,8 +107,13 @@ def test_expired_revoked_and_mismatched_grants_fail_closed(tmp_path):
             with pytest.raises(CapabilityError):  # wrong resource
                 service.validate_and_consume(session, wrong.id, "publish_post", "draft-999")
 
+            spend_approval = line.request_approval(
+                session, kind="spend", summary="Spend on one experiment",
+                payload={"resource": "exp-1", "max_cost": 25.0},
+            )
+            line.handle_command(session, f"YES {spend_approval.code}")
             budget = service.mint_from_approval(
-                session, approved.id, "spend", "spend on one experiment", "exp-1",
+                session, spend_approval.id, "spend", "spend on one experiment", "exp-1",
                 max_cost=25.0,
             )
             with pytest.raises(CapabilityError):  # over budget
@@ -160,6 +165,69 @@ def test_crisis_pause_suspends_grant_consumption(tmp_path, monkeypatch):
             service.validate_and_consume(session, grant.id, "publish_post", "draft-1")
         assert any(e["payload"]["reason"] == "crisis_paused"
                    for e in ledger.replay("capability_rejected"))
+    finally:
+        reset_shared_instances()
+
+
+def test_grant_may_only_narrow_the_approved_intent(tmp_path):
+    """The approved intent is immutable: a grant minted from it may cover
+    less than the human approved, never more."""
+    ledger, service, line = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            approved = _approved_request(session, line)  # payload names draft-1 only
+
+            # The named resource mints.
+            service.mint_from_approval(
+                session, approved.id, "publish_post", "publish draft-1", "draft-1",
+            )
+            # A resource the human never saw does not.
+            with pytest.raises(CapabilityError):
+                service.mint_from_approval(
+                    session, approved.id, "publish_post", "publish draft-2", "draft-2",
+                )
+
+            typed = line.request_approval(
+                session, kind="spend", summary="One paid experiment",
+                payload={"resource": "exp-7", "action_type": "spend", "max_cost": 40.0},
+            )
+            line.handle_command(session, f"YES {typed.code}")
+
+            with pytest.raises(CapabilityError):  # different action than approved
+                service.mint_from_approval(
+                    session, typed.id, "send_dm", "dm about exp-7", "exp-7",
+                )
+            with pytest.raises(CapabilityError):  # richer budget than approved
+                service.mint_from_approval(
+                    session, typed.id, "spend", "spend on exp-7", "exp-7", max_cost=41.0,
+                )
+            # Narrower on every axis: same action, same resource, smaller ceiling.
+            narrowed = service.mint_from_approval(
+                session, typed.id, "spend", "spend on exp-7", "exp-7", max_cost=10.0,
+            )
+            assert narrowed.max_cost == 10.0
+
+        reasons = {e["payload"]["reason"] for e in ledger.replay("capability_rejected")}
+        assert {"resource_outside_approved_intent", "action_outside_approved_intent",
+                "cost_above_approved_intent"} <= reasons
+    finally:
+        reset_shared_instances()
+
+
+def test_approval_without_declared_scope_imposes_no_narrowing(tmp_path):
+    """Operator approvals that carry no payload scope stay usable: the
+    binding narrows what the human declared, it does not invent limits."""
+    ledger, service, line = _setup(tmp_path)
+    try:
+        with get_db_session() as session:
+            request = line.request_approval(
+                session, kind="publish", summary="Publish today's thread",
+            )
+            line.handle_command(session, f"YES {request.code}")
+            grant = service.mint_from_approval(
+                session, request.id, "publish_post", "publish thread-9", "thread-9",
+            )
+        assert grant.resource == "thread-9"
     finally:
         reset_shared_instances()
 


### PR DESCRIPTION
## What this changes

Minting a `CapabilityGrant` previously verified only that *some* `ApprovalRequest` existed and was approved. The human's declared intent was checked for existence, not for scope — so an approval to publish `draft-1` could mint a grant that published `draft-2`, spent an arbitrary budget, or performed a different action entirely.

`mint_from_approval` now reads the approving request's payload as an immutable scope and refuses any grant that is wider than it:

- **Resource** — if the payload names resources (`resource`, `resources`, `draft_id`, `draft_ids`, `opportunity_packet_id`, `venture_assessment_id`, `target`, `targets`), the grant's resource must be one of them.
- **Action** — if the payload declares an `action_type`, the grant's action must match it.
- **Cost** — if the payload declares a `max_cost`, the grant's ceiling may not exceed it.

Each refusal is ledgered (`resource_outside_approved_intent`, `action_outside_approved_intent`, `cost_above_approved_intent`) so a rejected attempt survives in the record rather than vanishing.

An approval whose payload declares no scope imposes no narrowing. Free-text operator approvals (`YES <code>` on a summary with no structured payload) keep working exactly as before, so this is not a behavior change for existing flows.

## Why

The governing rule is that a grant may **narrow** an approved intent and never **broaden** it. Without this check the approval record and the capability record could diverge, which would make the decision ledger an unreliable account of what a human actually authorized.

## Tests

`tests/test_capability_grants.py` gains two cases:

- `test_grant_may_only_narrow_the_approved_intent` — the named resource mints; an unnamed resource, a different action, and a richer budget all fail; a grant narrower on every axis succeeds; all three rejection reasons appear in the ledger.
- `test_approval_without_declared_scope_imposes_no_narrowing` — a payload-less operator approval still mints.

Full suite: 295 passed.

## Safety posture (unchanged)

`LIVE` remains false. Nothing in this change arms the system or performs an external action; it only makes the authorization check stricter. Minting is still possible **only** from a human-approved request, and execution-time `validate_and_consume` (ledger-chain check, crisis pause, revocation, expiry, uses, action, resource, target, cost) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjuRe9SzeRJf5RMnPFzeRB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjuRe9SzeRJf5RMnPFzeRB)_