### PR TITLE
Recognise "kernel" as a transport identity — authentication only, never authority

### DIFF
--- a/services/bridge_security.py
+++ b/services/bridge_security.py
@@ -12,6 +12,15 @@ required in both directions and verification failures fail closed.
 A valid signature proves sender authenticity ONLY. It never carries
 authorization: a perfectly signed assessment still has no execution
 authority and still routes through the human approval queue.
+
+IDENTITY ISOLATION LIMIT — read before trusting an identity here.
+All mirrors of this module share ONE ``WEALTHMACHINE_SIGNING_KEY``. A
+recognised identity is therefore a CLAIMED identity, not a
+cryptographically isolated per-service identity: any holder of the shared
+secret can assert any name in ``KNOWN_IDENTITIES``. This is adequate for
+distinguishing well-formed peers on a trusted channel and inadequate as
+an authentication boundary between mutually distrusting services.
+Per-service keys or mTLS is the hardening step; it is not done.
 """
 
 from __future__ import annotations
@@ -35,7 +44,11 @@ H_SCHEMA = "X-Schema-Version"
 H_SIGNATURE = "X-Signature"
 H_TRACE = "X-Trace-Id"
 
-KNOWN_IDENTITIES = frozenset({"daleobanks", "wealthmachine"})
+# "kernel" is TRANSPORT AUTHENTICATION ONLY. It lets kernel-originated payloads
+# be recognised as well-formed; it grants no execution rights whatsoever. A
+# kernel-signed message still passes signature, timestamp, nonce/replay, schema,
+# capability, approval and consequence gates exactly like any other sender.
+KNOWN_IDENTITIES = frozenset({"daleobanks", "wealthmachine", "kernel"})
 
 
 class BridgeSecurityError(PermissionError):

--- a/tests/test_kernel_transport_identity.py
+++ b/tests/test_kernel_transport_identity.py
@@ -1,0 +1,175 @@
+"""The kernel is a recognised sender. It is not a privileged one.
+
+This is the DALEOBANKS half of the one-line change the UNIIMENTE Phase Zero
+report has listed as an open blocker since 2026-07-20: kernel-signed messages
+could not verify here because `kernel` was absent from `KNOWN_IDENTITIES`.
+
+Recognition is the whole of the change. Every test below exists to pin the
+boundary of what was granted:
+
+- a correctly signed kernel message verifies, and
+- a kernel message that is forged, replayed or stale still fails closed, and
+- verification returns transport facts only — no authority, no role, nothing
+  that distinguishes `kernel` from any other known sender.
+
+The shared-secret limit is asserted too, so nobody later reads "recognised"
+as "authenticated in isolation". All mirrors share one signing key, so any
+holder of that key can assert any known identity.
+"""
+
+import time
+
+import pytest
+
+from services.bridge_security import (
+    H_IDEMPOTENCY,
+    H_IDENTITY,
+    H_NONCE,
+    H_SCHEMA,
+    H_SIGNATURE,
+    H_TIMESTAMP,
+    KNOWN_IDENTITIES,
+    MIN_SCHEMA_VERSION,
+    SIGNING_KEY_ENV,
+    BridgeSecurityError,
+    NonceCache,
+    build_headers,
+    sign,
+)
+
+KEY = "test-signing-key"
+BODY = b'{"packet":"x"}'
+SCHEMA = MIN_SCHEMA_VERSION
+
+
+@pytest.fixture(autouse=True)
+def _signing_key(monkeypatch):
+    """Signing is only required once a key exists. Every test here needs one."""
+    monkeypatch.setenv(SIGNING_KEY_ENV, KEY)
+
+
+def _headers(identity="kernel", **over):
+    h = build_headers(BODY, identity=identity, schema_version=SCHEMA,
+                      idempotency_key="idem-1")
+    h.update(over)
+    return h
+
+
+def test_kernel_is_a_known_transport_identity():
+    assert "kernel" in KNOWN_IDENTITIES
+    assert {"daleobanks", "wealthmachine", "kernel"} == set(KNOWN_IDENTITIES)
+
+
+def test_a_correctly_signed_kernel_message_verifies():
+    from services.bridge_security import verify_headers
+
+    result = verify_headers(_headers(), BODY, nonce_cache=NonceCache(),
+                            require_signature=True)
+    assert result["identity"] == "kernel"
+    assert result["signed"] == "true"
+
+
+def test_verification_returns_transport_facts_and_no_authority():
+    """Recognition must not smuggle in a role, a permission or a capability."""
+    from services.bridge_security import verify_headers
+
+    result = verify_headers(_headers(), BODY, nonce_cache=NonceCache(),
+                            require_signature=True)
+    assert set(result) <= {"identity", "schema_version", "signed",
+                           "idempotency_key", "trace_id"}
+    for forbidden in ("authority", "role", "permissions", "capabilities",
+                      "approved", "grant"):
+        assert forbidden not in result
+
+
+def test_kernel_gets_no_more_than_any_other_sender():
+    """The result shape for `kernel` is identical to the shape for a peer organ."""
+    from services.bridge_security import verify_headers
+
+    k = verify_headers(_headers("kernel"), BODY, nonce_cache=NonceCache(),
+                       require_signature=True)
+    w = verify_headers(_headers("wealthmachine"), BODY, nonce_cache=NonceCache(),
+                       require_signature=True)
+    assert set(k) == set(w)
+    assert {kk: vv for kk, vv in k.items() if kk != "identity"} == \
+           {kk: vv for kk, vv in w.items() if kk != "identity"}
+
+
+# ------------------------------------------------------------- fails closed
+def test_forged_kernel_signature_fails_closed():
+    from services.bridge_security import verify_headers
+
+    bad = _headers(**{H_SIGNATURE: "0" * 64})
+    with pytest.raises(BridgeSecurityError, match="signature"):
+        verify_headers(bad, BODY, nonce_cache=NonceCache(), require_signature=True)
+
+
+def test_kernel_identity_with_a_tampered_body_fails_closed():
+    from services.bridge_security import verify_headers
+
+    with pytest.raises(BridgeSecurityError, match="signature"):
+        verify_headers(_headers(), b'{"packet":"tampered"}', nonce_cache=NonceCache(),
+                       require_signature=True)
+
+
+def test_replayed_kernel_nonce_fails_closed():
+    from services.bridge_security import verify_headers
+
+    cache = NonceCache()
+    headers = _headers()
+    assert verify_headers(headers, BODY, nonce_cache=cache, require_signature=True)
+    with pytest.raises(BridgeSecurityError, match="replay"):
+        verify_headers(headers, BODY, nonce_cache=cache, require_signature=True)
+
+
+def test_stale_kernel_timestamp_fails_closed():
+    from services.bridge_security import MAX_SKEW_SECONDS, verify_headers
+
+    stale = str(int(time.time()) - MAX_SKEW_SECONDS - 60)
+    nonce = "replay-me-not"
+    headers = {
+        H_IDENTITY: "kernel", H_TIMESTAMP: stale, H_NONCE: nonce,
+        H_IDEMPOTENCY: "idem-1", H_SCHEMA: SCHEMA,
+    }
+    headers[H_SIGNATURE] = sign(KEY, "kernel", stale, nonce, "idem-1", SCHEMA, BODY)
+    with pytest.raises(BridgeSecurityError, match="timestamp"):
+        verify_headers(headers, BODY, nonce_cache=NonceCache(), require_signature=True)
+
+
+def test_an_unknown_identity_is_still_refused():
+    from services.bridge_security import verify_headers
+
+    with pytest.raises(BridgeSecurityError, match="unknown service identity"):
+        verify_headers(_headers(**{H_IDENTITY: "railscout"}), BODY, nonce_cache=NonceCache(),
+                       require_signature=True)
+
+
+def test_schema_downgrade_is_still_rejected_for_the_kernel():
+    from services.bridge_security import verify_headers
+
+    with pytest.raises(BridgeSecurityError, match="downgrade"):
+        verify_headers(_headers(**{H_SCHEMA: "0.9"}), BODY, nonce_cache=NonceCache(),
+                       require_signature=True)
+
+
+# ------------------------------------------------- the limit of this change
+def test_the_shared_secret_means_identity_is_claimed_not_isolated():
+    """Any holder of the one shared key can assert any known identity.
+
+    Recorded as an executable fact so "recognised" is never read as
+    "cryptographically isolated". Per-service keys or mTLS is the hardening
+    step, and it is not done.
+    """
+    from services.bridge_security import verify_headers
+
+    # A caller who holds the key but is not the kernel signs as the kernel,
+    # and the transport cannot tell the difference. That is the limit.
+    impersonation = build_headers(BODY, identity="kernel",
+                                  schema_version=SCHEMA, idempotency_key="idem-2")
+    result = verify_headers(impersonation, BODY, nonce_cache=NonceCache(),
+                            require_signature=True)
+    assert result["identity"] == "kernel"
+
+    doc = __import__("services.bridge_security", fromlist=["x"]).__doc__
+    assert "CLAIMED identity" in doc
+    assert "Per-service keys or mTLS" in doc


### PR DESCRIPTION
## Purpose

Closes the one-line blocker the UNIIMENTE Phase Zero report has carried since 2026-07-20. `KNOWN_IDENTITIES` held `{"daleobanks", "wealthmachine"}`, so kernel-signed messages could not verify here and the kernel could not reach this organ at all.

```diff
-KNOWN_IDENTITIES = frozenset({"daleobanks", "wealthmachine"})
+KNOWN_IDENTITIES = frozenset({"daleobanks", "wealthmachine", "kernel"})
```

Plus a docstring recording the limit, and 11 narrow tests. Nothing else.

## Reality status

- [ ] Live · [ ] Sandbox · [ ] Simulated · [x] **Proposed**

## Recognition is the entire change

A kernel-signed message still passes signature, timestamp, nonce/replay, schema, capability, approval and consequence gates exactly like any other sender. `verify_headers` returns the same transport facts for `kernel` as for any peer — and that is asserted rather than assumed:

- `test_verification_returns_transport_facts_and_no_authority` — the result carries no `authority`, `role`, `permissions`, `capabilities`, `approved` or `grant` key.
- `test_kernel_gets_no_more_than_any_other_sender` — the result shape for `kernel` is identical to the shape for `wealthmachine`, field for field.

## The limit, recorded rather than glossed

All mirrors of this module share **one** `WEALTHMACHINE_SIGNING_KEY`. A recognised identity is therefore a **CLAIMED** identity, not a cryptographically isolated per-service identity: any holder of the shared secret can assert any name in `KNOWN_IDENTITIES`.

That is adequate for distinguishing well-formed peers on a trusted channel and **inadequate as an authentication boundary between mutually distrusting services.** Per-service keys or mTLS is the hardening step, and it is not done.

`test_the_shared_secret_means_identity_is_claimed_not_isolated` proves the impersonation **succeeds**, so nobody can later read "recognised" as "authenticated in isolation". The docstring says the same thing where a reader will hit it first.

## Fails closed, still

| Attack | Result |
|---|---|
| Forged signature | refused |
| Tampered body | refused |
| Replayed nonce | refused |
| Stale timestamp | refused |
| Unknown identity (`railscout`) | refused |
| Schema downgrade | refused |

## Verification

```
python -m pytest tests/test_kernel_transport_identity.py    11 passed
python -m pytest                                            280 passed, 24 failed
```

Those 24 failures are **pre-existing and unrelated** — a `cryptography` pyo3 panic in this container. Verified by stashing this change and re-running: baseline is **269 passed with the identical 24 failures**. The delta is exactly these 11 tests.

Kept field-for-field compatible with the WealthMachineIntelligence mirror (diff is one word: "Mirrored in" vs "Mirrored from").

## Authority and safety

- [x] No execution rights conferred. Transport authentication only.
- [x] No new authority source; the human approval queue is untouched.
- [x] The isolation limit is stated in code, in the docstring, and in an executable test.
- [x] Rollback: revert one commit. Two files, one of them new.

**Merge order:** the kernel branch lands first — it is the shared source of truth. This is second. See `handoff/contract.json` in `dababiyoda/uniimente-kernel#71`.

Draft, unmerged. Decision owner: **Alfonso Lopez**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ao5gTL8a3hs74XDp37J9HQ)_